### PR TITLE
chore(pkg): add homepage and bugs URLs to published packages

### DIFF
--- a/packages/fix-dict-fix44/package.json
+++ b/packages/fix-dict-fix44/package.json
@@ -36,6 +36,8 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix-dict-fix44"
   },
+  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/fix/package.json
+++ b/packages/fix/package.json
@@ -40,6 +40,8 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix"
   },
+  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"
   },


### PR DESCRIPTION
Adds `homepage` and `bugs` fields to the two publishable packages so their npm pages link back to the repo and issue tracker. No code change.

Also serves as a verification of the PR CI path (build/test matrix, lint, format, bundle, **DCO sign-off gate**).

🤖 Generated with [Claude Code](https://claude.com/claude-code)