### PR TITLE
ci: add Changesets release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,48 @@
+name: Release
+
+# When commits land on main:
+#   - if there are pending changesets, open/refresh a "Version Packages" PR;
+#   - once that PR is merged (no changesets left), build and publish to npm.
+# Requires an NPM_TOKEN repository secret (an npm automation/granular token with publish
+# rights to the @boarteam scope — automation tokens bypass 2FA, so no OTP is needed).
+on:
+  push:
+    branches: [main]
+
+concurrency: release
+
+permissions:
+  contents: write # create tags/releases and the version PR's commit
+  pull-requests: write # open the "Version Packages" PR
+  id-token: write # npm provenance (supply-chain attestation)
+
+jobs:
+  release:
+    name: version or publish
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install pnpm
+        uses: pnpm/action-setup@v4
+
+      - name: Use Node 20
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: pnpm
+          registry-url: https://registry.npmjs.org
+
+      - run: pnpm install --frozen-lockfile
+
+      - name: Create Release PR or publish to npm
+        uses: changesets/action@v1
+        with:
+          version: pnpm version-packages
+          publish: pnpm release
+          commit: 'chore(release): version packages'
+          title: 'chore(release): version packages'
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+          NPM_CONFIG_PROVENANCE: 'true'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -61,6 +61,21 @@ pnpm changeset
 Pre-1.0 SemVer: breaking changes to the **output shape**, **accepted input**, or **issue
 codes** are a minor bump and must be called out in the changeset. See `CHANGELOG.md`.
 
+## Releasing (maintainers)
+
+Releases are automated by the [Release workflow](.github/workflows/release.yml) using the
+Changesets action:
+
+1. Merge PRs that include changesets into `main`.
+2. The workflow opens a **"chore(release): version packages"** PR that consumes the changesets,
+   bumps versions, and updates the changelogs.
+3. Merging that PR builds and **publishes to npm** (with provenance) and creates the git tags
+   and GitHub releases.
+
+This requires an `NPM_TOKEN` repository secret — an npm **automation/granular** token with
+publish rights to the `@boarteam` scope (automation tokens bypass 2FA, so no OTP is needed).
+A manual fallback is `pnpm -r build && pnpm -r publish --otp=<code>`.
+
 ## Commit sign-off (DCO)
 
 All commits must be signed off under the


### PR DESCRIPTION
Automates versioning + npm publish (with provenance) via the Changesets action, removing the manual 2FA OTP step for future releases.

**Action required after merge:** add an `NPM_TOKEN` repo secret — an npm automation/granular token with publish rights to the `@boarteam` scope.

The workflow only acts on pushes to `main`: it opens a version PR when changesets exist, and publishes when that PR merges. Merging this PR is a no-op (no pending changesets).

🤖 Generated with [Claude Code](https://claude.com/claude-code)