### PR TITLE
ci: skip DCO sign-off for bot-authored PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,9 @@ jobs:
 
   dco:
     name: DCO sign-off
-    # Skip bot PRs (Dependabot commits are not signed off; they are trusted automation).
-    if: github.event_name == 'pull_request' && github.actor != 'dependabot[bot]'
+    # Human PRs must sign off (DCO). Skip bot-authored PRs — Dependabot, Renovate, and the
+    # changesets "Version Packages" release PR are trusted automation that does not sign off.
+    if: github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot'
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4


### PR DESCRIPTION
## Problem

Merging #11 triggered the Changesets release workflow to auto-open #12 (`chore(release): version packages`, branch `changeset-release/main`, authored by `github-actions[bot]`). Its commit isn't signed off, so the **DCO sign-off** job fails it — the job currently only skips `dependabot[bot]`, not the release bot.

## Fix

Gate the DCO job on `github.event.pull_request.user.type != 'Bot'` instead of an actor allowlist. This skips the DCO check for **all** bot-authored PRs — the changesets "Version Packages" PR, Dependabot, Renovate, and any future automation — while human PRs still require a `Signed-off-by` line.

```yaml
if: github.event_name == 'pull_request' && github.event.pull_request.user.type != 'Bot'
```

## After merge

On merge to `main`, the changesets action re-runs and rebases the `changeset-release/main` branch onto the fixed workflow, so **#12 re-checks and goes green** with no manual action. This is a CI-only change (no package code, no changeset needed).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>

🤖 Generated with [Claude Code](https://claude.com/claude-code)
