### PR TITLE
docs: correct FIX 4.4 dictionary counts and drop circular cross-check claim

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -23,8 +23,10 @@ roadmap. Highlights so far:
 - Dictionary-driven, zero-dependency engine: tokenize, parse (with nested repeating-group
   reconstruction), validate (presence/enum/datatype/conditional), and a byte-accurate ordered
   encoder. Parse and validate return `FixIssue[]` and never throw.
-- The full FIX 4.4 dictionary (912 fields / 26 components / 93 messages / 25 datatypes),
-  generated from the specification and **cross-checked against QuickFIX `FIX44.xml`** by a CI
-  drift gate.
+- The full FIX 4.4 dictionary (912 fields / 93 messages / 105 components / 23 datatypes),
+  generated **directly from the QuickFIX `FIX44.xml`** data dictionary — so it is not
+  "cross-checked" against QuickFIX (that would be circular), and it records 36
+  `conditional-overlay-unmatched` coverage gaps. The CI drift gate instead cross-checks the FIX
+  4.2 dictionary (generated from the FIX Repository 2010 Edition) against QuickFIX `FIX42.xml`.
 - Runs in the browser and Node via `TextEncoder`/`TextDecoder`; a CI bundle check enforces the
   zero-dependency, browser-safe surface.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -36,9 +36,9 @@ pnpm -r build && pnpm -r typecheck && pnpm lint && pnpm format:check && pnpm tes
 `packages/fix-dict-fix44/src/dictionary.json` and `index.ts` are **generated** from the FIX 4.4
 specification and committed here as data. Do not edit them by hand.
 
-The generator and its QuickFIX `FIX44.xml` cross-check are maintained alongside the FIX spec,
-outside this repository. To change the dictionary, regenerate it with that tooling and commit
-the reconciled result — open an issue if you need a regeneration you can't produce yourself.
+The generator is maintained alongside the FIX spec, outside this repository. To change the
+dictionary, regenerate it with that tooling and commit the reconciled result — open an issue if
+you need a regeneration you can't produce yourself.
 
 ## Changesets (versioning)
 

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -12,8 +12,8 @@ A zero-dependency FIX toolkit that runs in the browser and in Node:
   reconstruction), validate (pure and non-throwing), and encode (dictionary-ordered, with
   byte-accurate `BodyLength`/`CheckSum`).
 - **`@boarteam/fix-dict-fix44`** — the complete FIX 4.4 dictionary as data (912 fields /
-  26 components / 93 messages / 25 datatypes), generated from the specification and
-  cross-checked against the QuickFIX `FIX44.xml` dictionary.
+  93 messages / 105 components / 23 datatypes), generated directly from the QuickFIX
+  `FIX44.xml` data dictionary (so not "cross-checked" against it — that would be circular).
 - **`@boarteam/fix-dict-fix42`** — the complete FIX 4.2 dictionary as data (405 fields /
   46 messages / 21 datatypes), generated from the official FIX 4.2 specification (FIX
   Repository, 2010 Edition) and cross-checked against the QuickFIX `FIX42.xml` dictionary.

--- a/packages/fix-dict-fix44/README.md
+++ b/packages/fix-dict-fix44/README.md
@@ -1,13 +1,12 @@
 # @boarteam/fix-dict-fix44
 
-The **complete FIX 4.4 dictionary as data** (912 fields / 26 components / 93 messages / 25
+The **complete FIX 4.4 dictionary as data** (912 fields / 93 messages / 105 components / 23
 datatypes) for the [`@boarteam/fix`](https://www.npmjs.com/package/@boarteam/fix) engine.
-Generated from the FIX 4.4 specification and cross-checked against the QuickFIX `FIX44.xml`
-dictionary by a CI drift gate — never hand-maintained.
+Generated directly from the QuickFIX `FIX44.xml` data dictionary — never hand-maintained.
 
 On a 0.x line and actively developed. See the
-[project README](https://github.com/boarteam/fix-protocol#readme) for coverage, the cross-check
-report, and declared coverage gaps.
+[project README](https://github.com/boarteam/fix-protocol#readme) for coverage and declared
+coverage gaps.
 
 ```ts
 import { createFixEngine } from '@boarteam/fix';


### PR DESCRIPTION
## What

Corrects stale FIX 4.4 dictionary counts and removes a circular "cross-checked against QuickFIX `FIX44.xml`" claim across the docs, bringing them in line with the already-corrected root `README.md`.

## Why

The shipped `@boarteam/fix-dict-fix44` dictionary actually has **912 fields / 93 messages / 105 components / 23 datatypes** (verified by reading `packages/fix-dict-fix44/dist/index.cjs`), plus **36 `conditional-overlay-unmatched` coverage gaps**. Several docs still carried the stale **"912 fields / 26 components / 93 messages / 25 datatypes"**.

They also claimed the FIX 4.4 dictionary is *"cross-checked against QuickFIX `FIX44.xml`"* by a CI drift gate. That is **circular**: FIX 4.4 is generated *directly from* QuickFIX `FIX44.xml`, so it cannot be cross-checked against it. Only **FIX 4.2** (generated from the FIX Repository 2010 Edition) is genuinely cross-checked against QuickFIX `FIX42.xml` by the CI drift gate.

## Changes

- **`packages/fix-dict-fix44/README.md`** — fixed header counts; replaced the circular cross-check line with "Generated directly from the QuickFIX `FIX44.xml` data dictionary"; dropped the misleading "cross-check report" pointer (this package has none).
- **`CHANGELOG.md`** (Unreleased) — fixed counts, replaced circular wording, added the 36 `conditional-overlay-unmatched` coverage gaps, and re-attributed the CI drift gate to FIX 4.2.
- **`docs/ROADMAP.md`** — fixed the FIX 4.4 bullet counts and cross-check claim.
- **`CONTRIBUTING.md`** — removed the "QuickFIX `FIX44.xml` cross-check" reference from the generated-dictionary section.

FIX 4.2 numbers (`405/46/2/21`) are correct and were left unchanged.

## Verification

```
node -e "const d=require('./packages/fix-dict-fix44/dist/index.cjs').dictionary; console.log(Object.keys(d.fields).length, Object.keys(d.messages).length, Object.keys(d.components).length, Object.keys(d.datatypes).length, (d.coverageGaps||[]).length)"
# => 912 93 105 23 36
```

## Note for reviewers

Two **published** 0.1.0 changelog entries (`packages/fix-dict-fix44/CHANGELOG.md`, `packages/fix/CHANGELOG.md`, commit `b9187e0`) also assert a FIX44 cross-check. They were left untouched here because rewriting published release history is a separate decision — happy to address in a follow-up if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)