### PR TITLE
feat(dict): typed tag/msgtype map extension helpers

### DIFF
--- a/.changeset/typed-map-helpers.md
+++ b/.changeset/typed-map-helpers.md
@@ -1,0 +1,7 @@
+---
+'@boarteam/fix': minor
+---
+
+New typed map helpers for extending dictionaries with venue-specific tags: `extendTags`, `invertTags`, `extendMsgTypes`, `invertMsgTypes`, plus the exported result types `ExtendTags`, `InvertTags`, `ExtendMsgTypes`, `InvertMsgTypes`.
+
+The helpers merge/invert the literal `Tags`/`MsgType` maps shipped by the dict packages while preserving exact literal typing (`Tags.SymbolName` hovers as `1007`; reverse maps give literal lookups for known tags plus the shipped `name | undefined` index fallback). Pure, total, zero runtime dependencies; TypeScript ≥ 5.0 required for `const` type parameters. No new issue codes.

--- a/packages/fix/src/dictionary/extendTags.test.ts
+++ b/packages/fix/src/dictionary/extendTags.test.ts
@@ -1,0 +1,165 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  type ExtendMsgTypes,
+  type ExtendTags,
+  type InvertMsgTypes,
+  type InvertTags,
+  extendMsgTypes,
+  extendTags,
+  invertMsgTypes,
+  invertTags,
+} from './extendTags';
+
+// A miniature stand-in for a shipped dict package's `Tags`/`MsgType` maps
+// (`as const`, literal-typed) — packages/fix tests never depend on the dict packages.
+// The `expectTypeOf` pins are enforced by `pnpm typecheck` (tsc covers src, tests included).
+const BaseTags = {
+  Symbol: 55,
+  SecurityID: 48,
+  NoRelatedSym: 146,
+} as const;
+
+const BaseMsgTypes = {
+  Logon: 'A',
+  SecurityList: 'y',
+} as const;
+
+describe('extendTags', () => {
+  const Tags = extendTags(BaseTags, { SymbolName: 1007, SymbolDigits: 1008 });
+
+  it('merges extension entries over the base map', () => {
+    expect(Tags).toEqual({
+      Symbol: 55,
+      SecurityID: 48,
+      NoRelatedSym: 146,
+      SymbolName: 1007,
+      SymbolDigits: 1008,
+    });
+  });
+
+  it('never mutates the base map', () => {
+    const base = { Symbol: 55 };
+    const extended = extendTags(base, { SymbolName: 1007 });
+    expect(base).toEqual({ Symbol: 55 });
+    expect(extended).not.toBe(base);
+  });
+
+  it('lets the extension win on a name collision (spread semantics)', () => {
+    const overridden = extendTags(BaseTags, { Symbol: 9955 });
+    expect(overridden.Symbol).toBe(9955);
+
+    // The type mirrors the runtime: the extension's literal replaces the base's —
+    // a key-remapped merge, never the `55 & 9955 = never` of a naive intersection.
+    expectTypeOf(overridden.Symbol).toEqualTypeOf<9955>();
+  });
+
+  it('keeps literal types for both base and extension entries', () => {
+    expectTypeOf(Tags.SymbolName).toEqualTypeOf<1007>();
+    expectTypeOf(Tags.Symbol).toEqualTypeOf<55>();
+    expectTypeOf<keyof typeof Tags>().toEqualTypeOf<
+      'Symbol' | 'SecurityID' | 'NoRelatedSym' | 'SymbolName' | 'SymbolDigits'
+    >();
+    expect(Tags.SymbolName).toBe(1007);
+  });
+});
+
+describe('invertTags', () => {
+  const Tags = extendTags(BaseTags, { SymbolName: 1007, SymbolDigits: 1008 });
+  const TagNames = invertTags(Tags);
+
+  it('inverts every entry (bijection, mirroring the shipped names.test.ts contract)', () => {
+    const names = Object.keys(Tags) as (keyof typeof Tags)[];
+    expect(Object.keys(TagNames)).toHaveLength(names.length);
+    for (const name of names) {
+      expect(TagNames[Tags[name]]).toBe(name);
+    }
+  });
+
+  it('returns undefined for tags outside the map', () => {
+    expect(TagNames[99999]).toBeUndefined();
+  });
+
+  it('keeps last-write-wins on duplicate tag values (spread parity)', () => {
+    // Two names on one tag is a data problem `extendDictionary` reports; the map
+    // helper stays total and mirrors object-spread semantics: the later key wins.
+    const clashed = invertTags({ Text: 58, ReasonText: 58 });
+    expect(clashed[58]).toBe('ReasonText');
+  });
+
+  it('types known tags as literals and arbitrary numbers as name | undefined', () => {
+    expectTypeOf(TagNames[1007]).toEqualTypeOf<'SymbolName'>();
+    expectTypeOf(TagNames[55]).toEqualTypeOf<'Symbol'>();
+
+    const someTag = Number(process.env['NON_LITERAL'] ?? 55);
+    const looked = TagNames[someTag];
+    expectTypeOf(looked).toEqualTypeOf<keyof typeof Tags | undefined>();
+    expect(looked).toBe('Symbol');
+  });
+});
+
+describe('extendMsgTypes / invertMsgTypes', () => {
+  const MsgType = extendMsgTypes(BaseMsgTypes, { CTraderPing: 'UP1' });
+  const MsgTypeNames = invertMsgTypes(MsgType);
+
+  it('merges and inverts message-type maps', () => {
+    expect(MsgType).toEqual({ Logon: 'A', SecurityList: 'y', CTraderPing: 'UP1' });
+    const names = Object.keys(MsgType) as (keyof typeof MsgType)[];
+    expect(Object.keys(MsgTypeNames)).toHaveLength(names.length);
+    for (const name of names) {
+      expect(MsgTypeNames[MsgType[name]]).toBe(name);
+    }
+  });
+
+  it('returns undefined for unknown values', () => {
+    expect(MsgTypeNames['ZZ']).toBeUndefined();
+  });
+
+  it('keeps literal types on both sides', () => {
+    expectTypeOf(MsgType.CTraderPing).toEqualTypeOf<'UP1'>();
+    expectTypeOf(MsgTypeNames['UP1']).toEqualTypeOf<'CTraderPing'>();
+
+    const someType = String(process.env['NON_LITERAL'] ?? 'A');
+    const looked = MsgTypeNames[someType];
+    expectTypeOf(looked).toEqualTypeOf<keyof typeof MsgType | undefined>();
+    expect(looked).toBe('Logon');
+  });
+});
+
+describe('typing edge cases', () => {
+  it('degrades (but compiles) when the extension was pre-declared with a widened type', () => {
+    // Passing a widened variable cannot keep literals — the `const` type parameter
+    // only pins call-site literals. The result is still a correct runtime map; the
+    // one-declaration path (`defineExtension`, next milestone) turns this into a
+    // compile error instead.
+    const widened: Record<string, number> = { SymbolName: 1007 };
+    const Tags = extendTags(BaseTags, widened);
+    expect(Tags['SymbolName']).toBe(1007);
+    // `undefined` joins via noUncheckedIndexedAccess: the widened map erases the
+    // literal keys, so access falls through to the index signature.
+    expectTypeOf(Tags['SymbolName']).toEqualTypeOf<number | undefined>();
+  });
+
+  it('annotated exports type-check (the .d.ts-size escape hatch for venue packages)', () => {
+    // Venue modules that emit declarations should annotate with the alias types so
+    // tsc emits nominal references instead of inlining the full base map structurally.
+    const ext = { SymbolName: 1007, SymbolDigits: 1008 } as const;
+    const Tags: ExtendTags<typeof BaseTags, typeof ext> = extendTags(BaseTags, ext);
+    const TagNames: InvertTags<typeof Tags> = invertTags(Tags);
+    const MsgType: ExtendMsgTypes<typeof BaseMsgTypes, { readonly CTraderPing: 'UP1' }> =
+      extendMsgTypes(BaseMsgTypes, { CTraderPing: 'UP1' });
+    const MsgTypeNames: InvertMsgTypes<typeof MsgType> = invertMsgTypes(MsgType);
+
+    expectTypeOf(Tags.SymbolName).toEqualTypeOf<1007>();
+    expectTypeOf(TagNames[1008]).toEqualTypeOf<'SymbolDigits'>();
+    expectTypeOf(MsgTypeNames['UP1']).toEqualTypeOf<'CTraderPing'>();
+    expect(TagNames[1008]).toBe('SymbolDigits');
+    expect(MsgTypeNames['UP1']).toBe('CTraderPing');
+  });
+
+  it('computed keys built from extended tags stay number-valued', () => {
+    const Tags = extendTags(BaseTags, { SymbolName: 1007 });
+    // boar-trading indexes records by tag: `{ [Tags.X]: … }` must compile.
+    const byTag = { [Tags.SymbolName]: 'EURUSD' };
+    expect(byTag[1007]).toBe('EURUSD');
+  });
+});

--- a/packages/fix/src/dictionary/extendTags.ts
+++ b/packages/fix/src/dictionary/extendTags.ts
@@ -1,0 +1,125 @@
+/**
+ * Typed helpers for extending the literal `Tags`/`MsgType` maps shipped by the
+ * dictionary packages (`@boarteam/fix-dict-fix44`, `@boarteam/fix-dict-fix42`) with
+ * venue-specific entries — keeping the exact literal typing of the shipped maps
+ * (`Tags.SymbolName` hovers as `1007`, not `number`) at zero runtime cost.
+ *
+ * These are the *map* helpers: total, pure functions over plain `name → tag` /
+ * `name → msgType` records, independent of any dictionary. They intentionally emit
+ * no issues — a name or tag collision in a map is a data-level problem that
+ * `extendDictionary` reports when the same extension is applied to a
+ * {@link ./types.DictionaryJSON}; the map layer mirrors object-spread semantics
+ * (later entry wins) so types and runtime never disagree.
+ *
+ * Venue packages that emit declaration files should annotate their exports with the
+ * {@link ExtendTags}/{@link InvertTags} alias types: an unannotated export makes tsc
+ * inline the full base map *structurally* into the `.d.ts` (hundreds of kilobytes for
+ * a FIX 4.4-sized map); the annotation keeps the emit nominal and small.
+ */
+
+/**
+ * The result of {@link extendTags}: a key-remapped merge where extension keys
+ * cleanly REPLACE base keys. Deliberately not a bare intersection — with
+ * `B & T`, a name present in both with different tags would collapse to
+ * `55 & 9955 = never`; here it types as the extension's literal, matching the
+ * runtime spread.
+ */
+export type ExtendTags<
+  B extends Record<string, number>,
+  T extends Record<string, number>,
+> = Readonly<Omit<B, keyof T> & T>;
+
+/**
+ * The result of {@link invertTags}: the precise `tag → name` mapped inversion
+ * (so `TagNames[1007]` hovers as its literal name) intersected with the widened
+ * index signature the shipped packages use (so `TagNames[someNumber]` is
+ * `name | undefined`, never a type error).
+ */
+export type InvertTags<T extends Record<string, number>> = {
+  readonly [K in keyof T as T[K] & number]: K & string;
+} & { readonly [tag: number]: (keyof T & string) | undefined };
+
+/** {@link ExtendTags} for `MsgType` maps (`name → msgType` strings). */
+export type ExtendMsgTypes<
+  B extends Record<string, string>,
+  T extends Record<string, string>,
+> = Readonly<Omit<B, keyof T> & T>;
+
+/** {@link InvertTags} for `MsgType` maps: `msgType → name` with a string index. */
+export type InvertMsgTypes<T extends Record<string, string>> = {
+  readonly [K in keyof T as T[K] & string]: K & string;
+} & { readonly [msgType: string]: (keyof T & string) | undefined };
+
+/**
+ * Merge venue-specific tag entries over a base `Tags` map, keeping every literal
+ * type. The `const` type parameter (TS ≥ 5.0) pins call-site literals without
+ * `as const`; on a name collision the extension wins (object-spread semantics),
+ * and the {@link ExtendTags} result type mirrors that exactly.
+ *
+ * Pure: returns a new object; never mutates `base` or `ext`.
+ *
+ * ```ts
+ * const Tags = extendTags(Fix44Tags, { SymbolName: 1007, SymbolDigits: 1008 });
+ * Tags.SymbolName; // typed 1007
+ * type TagName = keyof typeof Tags; // includes 'SymbolName'
+ * ```
+ *
+ * Note: literals survive only for call-site object literals (or `as const`
+ * values) — an extension pre-declared as `Record<string, number>` is already
+ * widened and yields `number`-typed entries.
+ */
+export function extendTags<
+  B extends Record<string, number>,
+  const T extends Record<string, number>,
+>(base: B, ext: T): ExtendTags<B, T> {
+  return { ...base, ...ext } as ExtendTags<B, T>;
+}
+
+/**
+ * Build the `tag → name` reverse of a `Tags` map, typed as {@link InvertTags}:
+ * literal lookups for known tags plus the shipped packages' widened
+ * `name | undefined` number index for arbitrary input.
+ *
+ * Total and silent by contract: two names sharing one tag resolve last-write-wins
+ * (mirroring what a spread-built forward map does); `extendDictionary` is where
+ * such collisions are *reported*. For a standalone bijection guarantee, assert
+ * `Object.keys(invertTags(m)).length === Object.keys(m).length` in a test, as the
+ * shipped packages' `names.test.ts` does.
+ */
+export function invertTags<const T extends Record<string, number>>(tags: T): InvertTags<T> {
+  const out: Record<number, string> = {};
+  for (const [name, tag] of Object.entries(tags)) {
+    out[tag] = name;
+  }
+  return out as InvertTags<T>;
+}
+
+/**
+ * Merge venue-specific message-type entries over a base `MsgType` map — the
+ * string-valued mirror of {@link extendTags}.
+ *
+ * ```ts
+ * const MsgType = extendMsgTypes(Fix44MsgType, { CTraderPing: 'UP1' });
+ * MsgType.CTraderPing; // typed 'UP1'
+ * ```
+ */
+export function extendMsgTypes<
+  B extends Record<string, string>,
+  const T extends Record<string, string>,
+>(base: B, ext: T): ExtendMsgTypes<B, T> {
+  return { ...base, ...ext } as ExtendMsgTypes<B, T>;
+}
+
+/**
+ * Build the `msgType → name` reverse of a `MsgType` map — the string-valued
+ * mirror of {@link invertTags}.
+ */
+export function invertMsgTypes<const T extends Record<string, string>>(
+  msgTypes: T,
+): InvertMsgTypes<T> {
+  const out: Record<string, string> = {};
+  for (const [name, msgType] of Object.entries(msgTypes)) {
+    out[msgType] = name;
+  }
+  return out as InvertMsgTypes<T>;
+}

--- a/packages/fix/src/index.ts
+++ b/packages/fix/src/index.ts
@@ -60,5 +60,14 @@ export type {
   CoverageGap,
 } from './dictionary/types';
 
+// Dictionary extension helpers (typed maps).
+export { extendTags, invertTags, extendMsgTypes, invertMsgTypes } from './dictionary/extendTags';
+export type {
+  ExtendTags,
+  InvertTags,
+  ExtendMsgTypes,
+  InvertMsgTypes,
+} from './dictionary/extendTags';
+
 // Diagnostics.
 export type { FixIssue, FixSeverity, KnownIssueCode } from './errors';


### PR DESCRIPTION
## What

First slice of the dictionary-extensibility milestone: four pure, standalone helpers in `@boarteam/fix` for extending the literal `Tags`/`MsgType` maps shipped by the dict packages with venue-specific entries — without losing literal typing.

- `extendTags(base, ext)` / `extendMsgTypes(base, ext)` — key-remapped merge; the extension wins on a name collision (mirrors spread semantics, never the `55 & 9955 = never` naive-intersection trap). TS 5 `const` type parameters keep call-site literals: `Tags.SymbolName` hovers as `1007`.
- `invertTags(tags)` / `invertMsgTypes(msgTypes)` — reverse maps typed as the precise mapped inversion (`TagNames[1007]` hovers `'SymbolName'`) intersected with the shipped packages' widened index signature (`TagNames[n]` is `name | undefined`).
- Exported result types `ExtendTags`/`InvertTags`/`ExtendMsgTypes`/`InvertMsgTypes` — annotating venue-module exports with these keeps `.d.ts` emit nominal instead of structurally inlining the 900-key base map.

## Why

FIX venues extend dictionaries with custom tags (motivating case: cTrader's `SymbolName=1007`/`SymbolDigits=1008`). Consumers today hand-merge `{ ...Fix44Tags, SymbolName: 1007 }` and lose literal typing on the reverse map. These primitives are dictionary-independent and land first so adopters can migrate immediately; `extendDictionary` (runtime dictionary merge with `extend/*` issue codes) and the one-declaration `defineExtension` bridge follow in the next PR.

## Notes

- Helpers are total and silent by contract — collisions are a data-level concern reported by the upcoming `extendDictionary`; docs point standalone users at the one-line bijection assertion mirroring `names.test.ts`.
- Type-level pins use vitest's `expectTypeOf` and are enforced by `pnpm typecheck` (tsc covers colocated tests).
- TypeScript ≥ 5.0 required (`const` type parameters).
- Gate: typecheck ✓ · 276 tests ✓ · lint ✓ · build ✓ · check:bundle ✓ · dist smoke-tested (CJS **and** ESM).
- Changeset: minor for `@boarteam/fix`; no new issue codes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)