### PR TITLE
feat(dict): extendDictionary — venue extensions from one declaration

### DIFF
--- a/.changeset/extend-dictionary.md
+++ b/.changeset/extend-dictionary.md
@@ -1,0 +1,9 @@
+---
+'@boarteam/fix': minor
+---
+
+Dictionary extensibility: `extendDictionary(base, ...extensions)` merges venue extension declarations (new fields, enum values, components, messages, and placements into existing structures — including repeating groups behind components) into a fresh `DictionaryJSON`, plus the one-declaration bridge `defineExtension`/`tagsOf`/`msgTypesOf` that drives the typed maps from the same declaration.
+
+New stable issue codes (`extend/*` family, emitted by `extendDictionary`; severity encodes the outcome — error = skipped/reverted, warning = applied but review, info = advisory): `extend/field-tag-collision`, `extend/field-name-collision`, `extend/field-bad-tag`, `extend/field-unknown-type`, `extend/tag-outside-user-range`, `extend/data-length-unwired`, `extend/enum-unknown-field`, `extend/enum-value-conflict`, `extend/component-collision`, `extend/component-cycle`, `extend/msgtype-collision`, `extend/message-name-collision`, `extend/header-trailer-injected`, `extend/header-trailer-missing`, `extend/target-not-found`, `extend/unknown-member`, `extend/member-not-found`, `extend/duplicate-member`, `extend/counter-not-marked`, `extend/counter-as-field`, `extend/group-delimiter-shift`, `extend/ambiguous-boundary`, `extend/unresolvable-group-delimiter`, `extend/data-length-not-placed`, `extend/delimiter-defined`, `extend/component-fanout`, `extend/invalid-spec`.
+
+`DictionaryJSON` gains an optional `extensions?: string[]` provenance field listing applied extension ids. Placements are append/after-anchor only and guarded against delimiter shifts and nested-scope boundary ambiguity; applying an extension twice is a no-op. Requires TypeScript ≥ 5.0 for the literal-typing bridge.

--- a/packages/fix-dict-fix44/src/extend.test.ts
+++ b/packages/fix-dict-fix44/src/extend.test.ts
@@ -1,0 +1,154 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import {
+  type GroupMember,
+  createFixEngine,
+  defineExtension,
+  extendDictionary,
+  extendTags,
+  invertTags,
+  loadDictionary,
+  tagsOf,
+  toEncodeMessage,
+  validateDictionary,
+} from '@boarteam/fix';
+import { Tags, dictionary } from './index';
+
+// The motivating real-world case for dictionary extensibility: cTrader transmits
+// SymbolName(1007)/SymbolDigits(1008) INSIDE SecurityList's NoRelatedSym repeating
+// group. Without the extension the group walker treats 1007 as "group ended", walks
+// out after the first instrument, and mis-nests everything that follows.
+const ctrader = defineExtension({
+  id: 'ctrader',
+  fields: {
+    SymbolName: { tag: 1007, type: 'String' },
+    SymbolDigits: { tag: 1008, type: 'int' },
+  },
+  messages: {
+    SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+  },
+});
+
+const { dictionary: extended, issues: extendIssues } = extendDictionary(dictionary, ctrader);
+
+/** A 3-instrument cTrader-style SecurityList, pipe-delimited (framing not asserted). */
+const RAW = [
+  '8=FIX.4.4',
+  '9=0',
+  '35=y',
+  '49=cServer',
+  '56=client',
+  '34=2',
+  '52=20260712-09:00:00',
+  '320=req-1',
+  '322=resp-1',
+  '560=0',
+  '146=3',
+  '55=1',
+  '1007=EURUSD',
+  '1008=5',
+  '55=2',
+  '1007=GBPUSD',
+  '1008=5',
+  '55=3',
+  '1007=USDJPY',
+  '1008=3',
+  '10=000',
+  '',
+].join('|');
+
+describe('extending FIX 4.4 with the cTrader SecurityList tags', () => {
+  it('applies with advisory issues only and stays gate-clean', () => {
+    expect(extendIssues.filter((i) => i.severity !== 'info')).toEqual([]);
+    const codes = extendIssues.map((i) => i.code);
+    expect(codes.filter((c) => c === 'extend/tag-outside-user-range')).toHaveLength(2);
+    const fanout = extendIssues.find((i) => i.code === 'extend/component-fanout')!;
+    expect(fanout.message).toContain('SecListGrp');
+
+    expect(validateDictionary(extended)).toEqual([]);
+    expect(extended.extensions).toEqual(['ctrader']);
+    expect(extended.fields[1007]).toEqual({ tag: 1007, name: 'SymbolName', type: 'String' });
+  });
+
+  it('keeps the NoRelatedSym entry delimiter at Symbol (55) — regression pin', () => {
+    const dict = loadDictionary(extended);
+    const group = extended.components['SecListGrp']!.members[0] as GroupMember;
+    expect(group.counterTag).toBe(146);
+    expect(dict.groupDelimiterTag(group)).toBe(55);
+    // The custom tags sit at the END of the entry body:
+    expect(group.members.slice(-2)).toEqual([
+      { kind: 'field', tag: 1007, reqd: 'N' },
+      { kind: 'field', tag: 1008, reqd: 'N' },
+    ]);
+  });
+
+  it('mis-nests with the stock dictionary (the bug this feature fixes)', () => {
+    const stock = createFixEngine(dictionary);
+    const { message, issues } = stock.parse(RAW, { soh: '|', checkFraming: false });
+    expect(issues.map((i) => i.code)).toContain('parse/group-count-mismatch');
+    expect(message.groups[146] ?? []).not.toHaveLength(3);
+  });
+
+  it('parses a multi-instrument SecurityList correctly with the extended dictionary', () => {
+    const engine = createFixEngine(extended);
+    const { message, issues } = engine.parse(RAW, { soh: '|', checkFraming: false });
+    expect(issues).toEqual([]);
+
+    const entries = message.groups[146]!;
+    expect(entries).toHaveLength(3);
+    expect(entries.map((e) => e.fields[1007]!.raw)).toEqual(['EURUSD', 'GBPUSD', 'USDJPY']);
+    expect(entries.map((e) => e.fields[1008]!.value)).toEqual([5, 5, 3]);
+    expect(entries.map((e) => e.fields[55]!.raw)).toEqual(['1', '2', '3']);
+    // Nothing hoisted to the top level:
+    expect(message.fields[1007]).toBeUndefined();
+    expect(message.fields[55]).toBeUndefined();
+  });
+
+  it('round-trips: encode places the custom tags per entry and re-parse agrees', () => {
+    const engine = createFixEngine(extended);
+    const wire = engine.encode({
+      msgType: 'y',
+      fields: {
+        49: 'cServer',
+        56: 'client',
+        34: '2',
+        52: '20260712-09:00:00',
+        320: 'req-1',
+        322: 'resp-1',
+        560: '0',
+      },
+      groups: {
+        146: [
+          { fields: { 55: '1', 1007: 'EURUSD', 1008: '5' } },
+          { fields: { 55: '2', 1007: 'GBPUSD', 1008: '5' } },
+          { fields: { 55: '3', 1007: 'USDJPY', 1008: '3' } },
+        ],
+      },
+    });
+    // Each entry carries its own 1007/1008 (they round-trip, not just parse):
+    expect(wire.match(/1007=/g)).toHaveLength(3);
+
+    const { message, issues } = engine.parse(wire);
+    expect(issues).toEqual([]);
+    expect(message.framed).toBe(true);
+    const entries = message.groups[146]!;
+    expect(entries.map((e) => e.fields[1007]!.raw)).toEqual(['EURUSD', 'GBPUSD', 'USDJPY']);
+
+    // Byte-identical re-encode, and the dictionary conformance gate is clean:
+    expect(engine.encode(toEncodeMessage(message))).toBe(wire);
+    expect(engine.validate(message)).toEqual([]);
+  });
+
+  it('drives the typed maps from the same declaration', () => {
+    const VenueTags = extendTags(Tags, tagsOf(ctrader));
+    const VenueTagNames = invertTags(VenueTags);
+
+    expectTypeOf(VenueTags.SymbolName).toEqualTypeOf<1007>();
+    expectTypeOf(VenueTags.Symbol).toEqualTypeOf<55>();
+    expectTypeOf(VenueTagNames[1007]).toEqualTypeOf<'SymbolName'>();
+    expect(VenueTags.SymbolName).toBe(1007);
+    expect(VenueTagNames[1007]).toBe('SymbolName');
+    expect(VenueTagNames[55]).toBe('Symbol');
+    // The full base map survives: 900+ standard names plus the two venue tags.
+    expect(Object.keys(VenueTags).length).toBe(Object.keys(Tags).length + 2);
+  });
+});

--- a/packages/fix/src/dictionary/extendDictionary.test.ts
+++ b/packages/fix/src/dictionary/extendDictionary.test.ts
@@ -1,0 +1,899 @@
+import { describe, expect, it } from 'vitest';
+import type { FixIssue } from '../errors';
+import { extendDictionary } from './extendDictionary';
+import type { DictionaryExtension } from './extension';
+import type { DictionaryJSON, GroupMember } from './types';
+import { validateDictionary } from './validateDictionary';
+
+/**
+ * A minimal, internally consistent dictionary shaped like the structures that matter for
+ * extension semantics: a header/trailer pair, a shared component (`Instrument`, referenced
+ * twice), a single-reference component holding a repeating group (`SecListGrp`, the
+ * cTrader shape), and a nested group inside that group.
+ */
+function base(): DictionaryJSON {
+  return {
+    version: 'FIX.4.4',
+    beginString: 'FIX.4.4',
+    datatypes: {
+      int: { name: 'int', base: 'int' },
+      String: { name: 'String', base: 'String' },
+      data: { name: 'data', base: 'data' },
+      NumInGroup: { name: 'NumInGroup', base: 'int', parent: 'int' },
+    },
+    fields: {
+      8: { tag: 8, name: 'BeginString', type: 'String' },
+      35: { tag: 35, name: 'MsgType', type: 'String' },
+      34: { tag: 34, name: 'MsgSeqNum', type: 'int' },
+      49: { tag: 49, name: 'SenderCompID', type: 'String' },
+      10: { tag: 10, name: 'CheckSum', type: 'String' },
+      55: { tag: 55, name: 'Symbol', type: 'String' },
+      48: { tag: 48, name: 'SecurityID', type: 'String' },
+      58: { tag: 58, name: 'Text', type: 'String' },
+      320: { tag: 320, name: 'SecurityReqID', type: 'String' },
+      311: { tag: 311, name: 'UnderlyingSymbol', type: 'String' },
+      146: { tag: 146, name: 'NoRelatedSym', type: 'NumInGroup', isGroupCounter: true },
+      711: { tag: 711, name: 'NoUnderlyings', type: 'NumInGroup', isGroupCounter: true },
+    },
+    components: {
+      Header: {
+        name: 'Header',
+        members: [
+          { kind: 'field', tag: 8, reqd: 'Y' },
+          { kind: 'field', tag: 35, reqd: 'Y' },
+          { kind: 'field', tag: 49, reqd: 'Y' },
+          { kind: 'field', tag: 34, reqd: 'Y' },
+        ],
+      },
+      Trailer: { name: 'Trailer', members: [{ kind: 'field', tag: 10, reqd: 'Y' }] },
+      Instrument: {
+        name: 'Instrument',
+        members: [
+          { kind: 'field', tag: 55, reqd: 'Y' },
+          { kind: 'field', tag: 48, reqd: 'N' },
+        ],
+      },
+      SecListGrp: {
+        name: 'SecListGrp',
+        members: [
+          {
+            kind: 'group',
+            counterTag: 146,
+            reqd: 'N',
+            members: [
+              { kind: 'component', name: 'Instrument', reqd: 'Y' },
+              {
+                kind: 'group',
+                counterTag: 711,
+                reqd: 'N',
+                members: [{ kind: 'field', tag: 311, reqd: 'Y' }],
+              },
+            ],
+          },
+        ],
+      },
+    },
+    messages: [
+      {
+        name: 'SecurityList',
+        msgType: 'y',
+        category: 'app',
+        members: [
+          { kind: 'component', name: 'Header', reqd: 'Y' },
+          { kind: 'field', tag: 320, reqd: 'N' },
+          { kind: 'component', name: 'SecListGrp', reqd: 'Y' },
+          { kind: 'component', name: 'Trailer', reqd: 'Y' },
+        ],
+      },
+      {
+        name: 'Quote',
+        msgType: 'S',
+        category: 'app',
+        members: [
+          { kind: 'component', name: 'Header', reqd: 'Y' },
+          { kind: 'component', name: 'Instrument', reqd: 'Y' },
+          { kind: 'field', tag: 58, reqd: 'N' },
+          { kind: 'component', name: 'Trailer', reqd: 'Y' },
+        ],
+      },
+    ],
+  };
+}
+
+function codes(issues: FixIssue[]): string[] {
+  return issues.map((i) => i.code);
+}
+
+function byCode(issues: FixIssue[], code: string): FixIssue | undefined {
+  return issues.find((i) => i.code === code);
+}
+
+function errors(issues: FixIssue[]): FixIssue[] {
+  return issues.filter((i) => i.severity === 'error');
+}
+
+/** The group inside SecListGrp (owned by the component definition). */
+function secListGroup(d: DictionaryJSON): GroupMember {
+  return d.components['SecListGrp']!.members[0] as GroupMember;
+}
+
+describe('extendDictionary', () => {
+  it('starts from a gate-clean fixture', () => {
+    expect(validateDictionary(base())).toEqual([]);
+  });
+
+  describe('fields', () => {
+    it('adds new fields, inferring isGroupCounter from the datatype', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: {
+          SymbolName: { tag: 5001, type: 'String', description: 'venue name' },
+          NoVenueThings: { tag: 5002, type: 'NumInGroup' },
+        },
+      });
+      expect(errors(issues)).toEqual([]);
+      expect(dictionary.fields[5001]).toEqual({
+        tag: 5001,
+        name: 'SymbolName',
+        type: 'String',
+        description: 'venue name',
+      });
+      expect(dictionary.fields[5002]!.isGroupCounter).toBe(true);
+    });
+
+    it('skips a field whose tag is not a positive integer', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { Bad: { tag: 0, type: 'String' }, AlsoBad: { tag: 1.5, type: 'String' } },
+      });
+      expect(codes(issues)).toEqual(['extend/field-bad-tag', 'extend/field-bad-tag']);
+      expect(dictionary.fields[0]).toBeUndefined();
+    });
+
+    it('skips a field with an unknown datatype', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'Price' } },
+      });
+      expect(byCode(issues, 'extend/field-unknown-type')!.severity).toBe('error');
+      expect(dictionary.fields[5001]).toBeUndefined();
+    });
+
+    it('skips a field whose name is bound to a different tag', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { Symbol: { tag: 9001, type: 'String' } },
+      });
+      expect(byCode(issues, 'extend/field-name-collision')!.severity).toBe('error');
+      expect(dictionary.fields[9001]).toBeUndefined();
+      expect(dictionary.fields[55]!.name).toBe('Symbol');
+      // The skip keeps the merged dictionary gate-clean:
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('replaces an existing tag with a warning (extension wins)', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { ReasonText: { tag: 58, type: 'String' } },
+      });
+      expect(byCode(issues, 'extend/field-tag-collision')!.severity).toBe('warning');
+      expect(dictionary.fields[58]!.name).toBe('ReasonText');
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('is silent on a byte-identical redefinition (idempotency)', () => {
+      const { issues } = extendDictionary(base(), {
+        fields: { Symbol: { tag: 55, type: 'String' } },
+      });
+      expect(issues).toEqual([]);
+    });
+
+    it('notes tags outside the user-defined ranges, and only those', () => {
+      const { issues } = extendDictionary(base(), {
+        fields: {
+          SymbolName: { tag: 1007, type: 'String' },
+          VenueA: { tag: 5001, type: 'String' },
+          VenueB: { tag: 20001, type: 'String' },
+        },
+      });
+      const range = issues.filter((i) => i.code === 'extend/tag-outside-user-range');
+      expect(range).toHaveLength(1);
+      expect(range[0]!.severity).toBe('info');
+      expect(range[0]!.refTagID).toBe(1007);
+    });
+
+    it('warns on a data field without a companion length field', () => {
+      const { issues } = extendDictionary(base(), {
+        fields: {
+          VenueBlobLen: { tag: 5001, type: 'int' },
+          VenueBlob: { tag: 5002, type: 'data' },
+          WiredBlob: { tag: 5003, type: 'data', lengthField: 5001 },
+        },
+      });
+      const unwired = issues.filter((i) => i.code === 'extend/data-length-unwired');
+      expect(unwired).toHaveLength(1);
+      expect(unwired[0]!.refTagID).toBe(5002);
+    });
+  });
+
+  describe('enums', () => {
+    it('appends enum values to an existing field, defaulting description to name', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        enums: { Text: [{ value: '1', name: 'One' }] },
+      });
+      expect(errors(issues)).toEqual([]);
+      expect(dictionary.fields[58]!.enumValues).toEqual([
+        { value: '1', name: 'One', description: 'One' },
+      ]);
+    });
+
+    it('dedupes identical value+name pairs silently and replaces on name conflict', () => {
+      const once = extendDictionary(base(), { enums: { Text: [{ value: '1', name: 'One' }] } });
+      const again = extendDictionary(once.dictionary, {
+        enums: { Text: [{ value: '1', name: 'One' }] },
+      });
+      expect(again.issues).toEqual([]);
+      expect(again.dictionary.fields[58]!.enumValues).toHaveLength(1);
+
+      const conflicted = extendDictionary(once.dictionary, {
+        enums: { Text: [{ value: '1', name: 'Uno' }] },
+      });
+      expect(byCode(conflicted.issues, 'extend/enum-value-conflict')!.severity).toBe('warning');
+      expect(conflicted.dictionary.fields[58]!.enumValues).toEqual([
+        { value: '1', name: 'Uno', description: 'Uno' },
+      ]);
+    });
+
+    it('skips enum entries naming an unknown field', () => {
+      const { issues } = extendDictionary(base(), {
+        enums: { Nope: [{ value: '1', name: 'One' }] },
+      });
+      expect(byCode(issues, 'extend/enum-unknown-field')!.severity).toBe('error');
+    });
+  });
+
+  describe('components', () => {
+    it('defines a new component with resolved members', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        components: { Venue: { members: ['SymbolName', { field: 'Text', reqd: 'Y' }] } },
+      });
+      expect(errors(issues)).toEqual([]);
+      expect(dictionary.components['Venue']).toEqual({
+        name: 'Venue',
+        members: [
+          { kind: 'field', tag: 5001, reqd: 'N' },
+          { kind: 'field', tag: 58, reqd: 'Y' },
+        ],
+      });
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('skips a new component whose name already exists', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        components: { Instrument: { members: ['Text'] } },
+      });
+      expect(byCode(issues, 'extend/component-collision')!.severity).toBe('error');
+      expect(dictionary.components['Instrument']!.members).toHaveLength(2);
+    });
+
+    it('skips a whole new component when any member is unresolvable (atomic)', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        components: { Venue: { members: ['Text', 'NoSuchField'] } },
+      });
+      expect(byCode(issues, 'extend/unknown-member')!.severity).toBe('error');
+      expect(dictionary.components['Venue']).toBeUndefined();
+    });
+
+    it('appends to an existing component and reports the fan-out', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        components: { Instrument: { append: ['SymbolName'] } },
+      });
+      expect(errors(issues)).toEqual([]);
+      const fanout = byCode(issues, 'extend/component-fanout')!;
+      expect(fanout.severity).toBe('info');
+      expect(fanout.message).toContain('SecurityList');
+      expect(fanout.message).toContain('Quote');
+      const members = dictionary.components['Instrument']!.members;
+      expect(members[members.length - 1]).toEqual({ kind: 'field', tag: 5001, reqd: 'N' });
+    });
+
+    it('reports an unknown component patch target', () => {
+      const { issues } = extendDictionary(base(), { components: { Nope: { append: ['Text'] } } });
+      expect(byCode(issues, 'extend/target-not-found')!.severity).toBe('error');
+    });
+  });
+
+  describe('new messages', () => {
+    it('wraps a new message with the detected header/trailer and appends it', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: { VenuePing: { msgType: 'U1', members: ['Text'] } },
+      });
+      expect(errors(issues)).toEqual([]);
+      expect(byCode(issues, 'extend/header-trailer-injected')!.severity).toBe('info');
+      const message = dictionary.messages.find((m) => m.msgType === 'U1')!;
+      expect(message).toMatchObject({ name: 'VenuePing', category: 'app' });
+      expect(message.members).toEqual([
+        { kind: 'component', name: 'Header', reqd: 'Y' },
+        { kind: 'field', tag: 58, reqd: 'N' },
+        { kind: 'component', name: 'Trailer', reqd: 'Y' },
+      ]);
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('does not double-inject when the body already lists the header', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: {
+          VenuePing: { msgType: 'U1', members: [{ component: 'Header', reqd: 'Y' }, 'Text'] },
+        },
+      });
+      const message = dictionary.messages.find((m) => m.msgType === 'U1')!;
+      expect(
+        message.members.filter((m) => m.kind === 'component' && m.name === 'Header'),
+      ).toHaveLength(1);
+      expect(byCode(issues, 'extend/header-trailer-injected')!.message).toContain('Trailer');
+      expect(byCode(issues, 'extend/header-trailer-injected')!.message).not.toContain('"Header"');
+    });
+
+    it('warns and applies bare when no header/trailer is detectable', () => {
+      const bare = base();
+      for (const message of bare.messages) {
+        message.members = message.members.filter(
+          (m) => !(m.kind === 'component' && (m.name === 'Header' || m.name === 'Trailer')),
+        );
+      }
+      const { dictionary, issues } = extendDictionary(bare, {
+        messages: { VenuePing: { msgType: 'U1', members: ['Text'] } },
+      });
+      expect(byCode(issues, 'extend/header-trailer-missing')!.severity).toBe('warning');
+      const message = dictionary.messages.find((m) => m.msgType === 'U1')!;
+      expect(message.members).toEqual([{ kind: 'field', tag: 58, reqd: 'N' }]);
+    });
+
+    it('replaces an existing message with the same MsgType in place', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: { VenueQuote: { msgType: 'S', members: ['Text'] } },
+      });
+      expect(byCode(issues, 'extend/msgtype-collision')!.severity).toBe('warning');
+      expect(dictionary.messages).toHaveLength(2);
+      expect(dictionary.messages[1]!.name).toBe('VenueQuote'); // index of Quote preserved
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('warns when a new message duplicates another message name', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: { Quote: { msgType: 'U7', members: ['Text'] } },
+      });
+      expect(byCode(issues, 'extend/message-name-collision')!.severity).toBe('warning');
+      expect(dictionary.messages).toHaveLength(3);
+    });
+  });
+
+  describe('message patches', () => {
+    it('appends before the trailing trailer by default', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        messages: { Quote: { append: ['SymbolName'] } },
+      });
+      expect(errors(issues)).toEqual([]);
+      const members = dictionary.messages[1]!.members;
+      expect(members[members.length - 1]).toEqual({
+        kind: 'component',
+        name: 'Trailer',
+        reqd: 'Y',
+      });
+      expect(members[members.length - 2]).toEqual({ kind: 'field', tag: 5001, reqd: 'N' });
+    });
+
+    it('inserts right after an anchor member with after', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        messages: { Quote: { append: ['SymbolName'], after: 'Instrument' } },
+      });
+      expect(errors(issues)).toEqual([]);
+      const members = dictionary.messages[1]!.members;
+      expect(members[1]).toEqual({ kind: 'component', name: 'Instrument', reqd: 'Y' });
+      expect(members[2]).toEqual({ kind: 'field', tag: 5001, reqd: 'N' });
+    });
+
+    it('skips the placement when the after anchor is missing', () => {
+      const before = base().messages[1]!.members.length;
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        messages: { Quote: { append: ['SymbolName'], after: 'Nope' } },
+      });
+      expect(byCode(issues, 'extend/member-not-found')!.severity).toBe('error');
+      expect(dictionary.messages[1]!.members).toHaveLength(before);
+    });
+
+    it('skips the whole placement when any member is unresolvable (atomic)', () => {
+      const before = base().messages[1]!.members.length;
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        messages: { Quote: { append: ['SymbolName', 'NoSuchField'] } },
+      });
+      expect(byCode(issues, 'extend/unknown-member')!.severity).toBe('error');
+      expect(dictionary.messages[1]!.members).toHaveLength(before);
+    });
+
+    it('skips members already reachable in the scope (duplicate guard, incl. via components)', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: { Quote: { append: ['SecurityID', 'Text'] } },
+      });
+      const duplicates = issues.filter((i) => i.code === 'extend/duplicate-member');
+      expect(duplicates).toHaveLength(2); // 48 reachable via Instrument, 58 is direct
+      expect(duplicates.every((i) => i.severity === 'warning')).toBe(true);
+      expect(dictionary.messages[1]!.members).toHaveLength(base().messages[1]!.members.length);
+    });
+
+    it('reports unknown and ambiguous message targets', () => {
+      expect(
+        byCode(
+          extendDictionary(base(), { messages: { Nope: { append: ['Text'] } } }).issues,
+          'extend/target-not-found',
+        ),
+      ).toBeDefined();
+
+      const dup = base();
+      dup.messages.push({ ...dup.messages[1]!, msgType: 'S2' });
+      const { issues } = extendDictionary(dup, { messages: { Quote: { append: ['Text'] } } });
+      expect(byCode(issues, 'extend/target-not-found')!.message).toContain('ambiguous');
+    });
+  });
+
+  describe('group placements', () => {
+    const ctrader: DictionaryExtension = {
+      id: 'ctrader',
+      fields: {
+        SymbolName: { tag: 1007, type: 'String' },
+        SymbolDigits: { tag: 1008, type: 'int' },
+      },
+      messages: {
+        SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+      },
+    };
+
+    it('auto-descends into a group behind a single-reference component (the cTrader case)', () => {
+      const { dictionary, issues } = extendDictionary(base(), ctrader);
+      expect(errors(issues)).toEqual([]);
+      const fanout = byCode(issues, 'extend/component-fanout')!;
+      expect(fanout.severity).toBe('info');
+      expect(fanout.message).toContain('SecListGrp');
+      const group = secListGroup(dictionary);
+      expect(group.members.slice(-2)).toEqual([
+        { kind: 'field', tag: 1007, reqd: 'N' },
+        { kind: 'field', tag: 1008, reqd: 'N' },
+      ]);
+      expect(validateDictionary(dictionary)).toEqual([]);
+      expect(dictionary.extensions).toEqual(['ctrader']);
+    });
+
+    it('resolves dotted paths into nested groups', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        messages: {
+          SecurityList: { groups: { 'NoRelatedSym.NoUnderlyings': { append: ['SymbolName'] } } },
+        },
+      });
+      expect(errors(issues)).toEqual([]);
+      const nested = secListGroup(dictionary).members[1] as GroupMember;
+      expect(nested.counterTag).toBe(711);
+      expect(nested.members[nested.members.length - 1]).toEqual({
+        kind: 'field',
+        tag: 5001,
+        reqd: 'N',
+      });
+    });
+
+    it('refuses to descend through a shared component, with an explicit hint', () => {
+      const shared = base();
+      // Move the underlyings group inside Instrument (referenced by 2 scopes):
+      shared.components['Instrument']!.members.push({
+        kind: 'group',
+        counterTag: 711,
+        reqd: 'N',
+        members: [{ kind: 'field', tag: 311, reqd: 'Y' }],
+      });
+      const { issues } = extendDictionary(shared, {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        messages: { Quote: { groups: { NoUnderlyings: { append: ['SymbolName'] } } } },
+      });
+      const notFound = byCode(issues, 'extend/target-not-found')!;
+      expect(notFound.severity).toBe('error');
+      expect(notFound.message).toContain('Instrument');
+      expect(notFound.message).toContain('components');
+    });
+
+    it('reports a group path that resolves nowhere', () => {
+      const { issues } = extendDictionary(base(), {
+        messages: { Quote: { groups: { NoRelatedSym: { append: ['Text'] } } } },
+      });
+      expect(byCode(issues, 'extend/target-not-found')).toBeDefined();
+    });
+  });
+
+  describe('placement safety', () => {
+    it('rejects a field that would sit ambiguously after an open nested group', () => {
+      // 311 belongs to the nested NoUnderlyings scope; appended to the end of the outer
+      // NoRelatedSym entry it would re-parse INTO the nested group.
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: {
+          SecurityList: { groups: { NoRelatedSym: { append: ['UnderlyingSymbol'] } } },
+        },
+      });
+      const boundary = byCode(issues, 'extend/ambiguous-boundary')!;
+      expect(boundary.severity).toBe('error');
+      expect(boundary.refTagID).toBe(311);
+      expect(secListGroup(dictionary).members).toHaveLength(2); // nothing added
+    });
+
+    it('allows the same field when anchored ahead of the nested group', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: {
+          SecurityList: {
+            groups: { NoRelatedSym: { append: ['UnderlyingSymbol'], after: 'Instrument' } },
+          },
+        },
+      });
+      expect(errors(issues)).toEqual([]);
+      const group = secListGroup(dictionary);
+      expect(group.members[1]).toEqual({ kind: 'field', tag: 311, reqd: 'N' });
+      expect((group.members[2] as GroupMember).counterTag).toBe(711);
+    });
+
+    it('reverts a placement that would shift a group delimiter', () => {
+      const tricky = base();
+      tricky.fields[999] = { tag: 999, name: 'NoThings', type: 'NumInGroup', isGroupCounter: true };
+      tricky.components['EmptyLead'] = { name: 'EmptyLead', members: [] };
+      tricky.messages[1]!.members.splice(2, 0, {
+        kind: 'group',
+        counterTag: 999,
+        reqd: 'N',
+        // Delimiter resolves THROUGH the field-less leading component to Text (58):
+        members: [
+          { kind: 'component', name: 'EmptyLead', reqd: 'N' },
+          { kind: 'field', tag: 58, reqd: 'Y' },
+        ],
+      });
+      const { dictionary, issues } = extendDictionary(tricky, {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        components: { EmptyLead: { append: ['SymbolName'] } },
+      });
+      const shift = byCode(issues, 'extend/group-delimiter-shift')!;
+      expect(shift.severity).toBe('error');
+      expect(shift.message).toContain('NoThings');
+      expect(dictionary.components['EmptyLead']!.members).toEqual([]); // reverted
+    });
+
+    it('reports when a delimiter-less group body gains its first wire tag', () => {
+      const tricky = base();
+      tricky.fields[999] = { tag: 999, name: 'NoThings', type: 'NumInGroup', isGroupCounter: true };
+      tricky.components['EmptyLead'] = { name: 'EmptyLead', members: [] };
+      tricky.messages[1]!.members.splice(2, 0, {
+        kind: 'group',
+        counterTag: 999,
+        reqd: 'N',
+        members: [{ kind: 'component', name: 'EmptyLead', reqd: 'N' }],
+      });
+      const { dictionary, issues } = extendDictionary(tricky, {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        components: { EmptyLead: { append: ['SymbolName'] } },
+      });
+      expect(byCode(issues, 'extend/delimiter-defined')!.severity).toBe('info');
+      expect(dictionary.components['EmptyLead']!.members).toEqual([
+        { kind: 'field', tag: 5001, reqd: 'N' },
+      ]);
+    });
+
+    it('places a new nested repeating group and warns on a non-counter head', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: {
+          NoVenueAttrs: { tag: 5001, type: 'NumInGroup' },
+          VenueAttr: { tag: 5002, type: 'String' },
+          FakeCounter: { tag: 5003, type: 'int' },
+        },
+        messages: {
+          Quote: {
+            append: [
+              { group: 'NoVenueAttrs', members: ['VenueAttr'] },
+              { group: 'FakeCounter', members: ['VenueAttr'] },
+            ],
+          },
+        },
+      });
+      expect(byCode(issues, 'extend/counter-not-marked')!.severity).toBe('warning');
+      const members = dictionary.messages[1]!.members;
+      const groups = members.filter((m): m is GroupMember => m.kind === 'group');
+      expect(groups.map((g) => g.counterTag)).toEqual([5001, 5003]);
+      expect(groups[0]!.members).toEqual([{ kind: 'field', tag: 5002, reqd: 'N' }]);
+    });
+  });
+
+  describe('invariants', () => {
+    const ctrader: DictionaryExtension = {
+      id: 'ctrader',
+      fields: {
+        SymbolName: { tag: 1007, type: 'String' },
+        SymbolDigits: { tag: 1008, type: 'int' },
+      },
+      messages: {
+        SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+      },
+    };
+
+    it('never mutates the base or the extension', () => {
+      const original = base();
+      const snapshot = structuredClone(original);
+      const extSnapshot = structuredClone(ctrader);
+      extendDictionary(original, ctrader);
+      expect(original).toEqual(snapshot);
+      expect(ctrader).toEqual(extSnapshot);
+    });
+
+    it('is idempotent: re-applying an extension changes nothing, including provenance', () => {
+      const once = extendDictionary(base(), ctrader);
+      const twice = extendDictionary(once.dictionary, ctrader);
+      expect(twice.dictionary).toEqual(once.dictionary);
+      expect(twice.dictionary.extensions).toEqual(['ctrader']);
+      expect(codes(twice.issues)).toContain('extend/duplicate-member');
+      expect(errors(twice.issues)).toEqual([]);
+    });
+
+    it('composes left to right: later extensions see earlier ones', () => {
+      const { dictionary, issues } = extendDictionary(
+        base(),
+        { id: 'one', fields: { SymbolName: { tag: 1007, type: 'String' } } },
+        { id: 'two', messages: { Quote: { append: ['SymbolName'] } } },
+      );
+      expect(errors(issues)).toEqual([]);
+      const members = dictionary.messages[1]!.members;
+      expect(members[members.length - 2]).toEqual({ kind: 'field', tag: 1007, reqd: 'N' });
+      expect(dictionary.extensions).toEqual(['one', 'two']);
+    });
+
+    it('preserves gate-cleanliness when no error-severity issues were reported', () => {
+      const { dictionary, issues } = extendDictionary(base(), ctrader, {
+        fields: { VenueFlag: { tag: 5005, type: 'String' } },
+        enums: { VenueFlag: [{ value: 'A', name: 'Alpha' }] },
+        components: { VenueBlock: { members: ['VenueFlag'] } },
+        messages: {
+          VenuePing: { msgType: 'U1', members: [{ component: 'VenueBlock', reqd: 'Y' }] },
+        },
+      });
+      expect(errors(issues)).toEqual([]);
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('never throws on empty or degenerate extensions', () => {
+      expect(() => extendDictionary(base())).not.toThrow();
+      expect(() => extendDictionary(base(), {})).not.toThrow();
+      expect(() => extendDictionary(base(), null as unknown as DictionaryExtension)).not.toThrow();
+      expect(() =>
+        extendDictionary(base(), { fields: undefined, messages: undefined }),
+      ).not.toThrow();
+    });
+
+    it('reports malformed entries as extend/invalid-spec instead of throwing', () => {
+      const degenerate = {
+        fields: { Broken: null },
+        enums: { Text: 'nope' },
+        components: { C: 42 },
+        messages: { M: null, N: { msgType: 'U9' } }, // N: msgType without a members array
+      } as unknown as DictionaryExtension;
+      let issues!: FixIssue[];
+      expect(() => {
+        issues = extendDictionary(base(), degenerate).issues;
+      }).not.toThrow();
+      const invalid = issues.filter((i) => i.code === 'extend/invalid-spec');
+      expect(invalid.length).toBeGreaterThanOrEqual(5);
+      expect(invalid.every((i) => i.severity === 'error')).toBe(true);
+    });
+  });
+
+  describe('component cycles', () => {
+    it('deletes new components that form a reference cycle (self and mutual)', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        components: {
+          Loop: { members: [{ component: 'Loop' }] },
+          A: { members: [{ component: 'B' }] },
+          B: { members: [{ component: 'A' }] },
+        },
+      });
+      const cycles = issues.filter((i) => i.code === 'extend/component-cycle');
+      expect(cycles.length).toBeGreaterThanOrEqual(2); // Loop + at least one of A/B
+      expect(dictionary.components['Loop']).toBeUndefined();
+      expect(dictionary.components['A']).toBeUndefined();
+      expect(dictionary.components['B']).toBeUndefined();
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('reverts a placed component reference that would close a cycle', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        components: {
+          VenueBlock: { members: [{ component: 'Instrument' }] },
+          Instrument: { append: [{ component: 'VenueBlock' }] },
+        },
+      });
+      expect(byCode(issues, 'extend/component-cycle')!.severity).toBe('error');
+      expect(dictionary.components['Instrument']!.members).toHaveLength(2); // untouched
+      expect(dictionary.components['VenueBlock']).toBeDefined(); // itself fine
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('deletes new components left dangling by a skipped sibling (fixpoint)', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        components: {
+          // Declared BEFORE the broken one so its reference resolves in pass 2:
+          Dependent: { members: ['Text', { component: 'Bad' }] },
+          Bad: { members: ['NoSuchField'] },
+        },
+      });
+      expect(codes(issues)).toContain('extend/unknown-member');
+      expect(dictionary.components['Bad']).toBeUndefined();
+      expect(dictionary.components['Dependent']).toBeUndefined();
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+  });
+
+  describe('review-hardened placement safety', () => {
+    it('skips a new group whose body resolves to no entry delimiter', () => {
+      const { dictionary, issues } = extendDictionary(base(), {
+        components: { EmptyComp: { members: [] } },
+        messages: {
+          Quote: {
+            append: [
+              { group: 'NoUnderlyings', members: [{ component: 'EmptyComp' }] },
+              { group: 'NoRelatedSym', members: [] },
+            ],
+          },
+        },
+      });
+      const skipped = issues.filter((i) => i.code === 'extend/unresolvable-group-delimiter');
+      expect(skipped).toHaveLength(2);
+      expect(skipped.every((i) => i.severity === 'error')).toBe(true);
+      expect(dictionary.messages[1]!.members).toHaveLength(base().messages[1]!.members.length);
+      expect(validateDictionary(dictionary)).toEqual([]);
+    });
+
+    it('rejects a component-targeted append that lands after an open group in a referencing scope', () => {
+      const shared = base();
+      shared.components['Extras'] = { name: 'Extras', members: [] };
+      // Extras sits right AFTER the group-bearing component in SecurityList:
+      shared.messages[0]!.members.splice(3, 0, { kind: 'component', name: 'Extras', reqd: 'N' });
+      // Appending Symbol (55, in NoRelatedSym's scope) to Extras would put it on the wire
+      // straight after the group's entries in SecurityList:
+      const { dictionary, issues } = extendDictionary(shared, {
+        components: { Extras: { append: ['Symbol'] } },
+      });
+      expect(byCode(issues, 'extend/ambiguous-boundary')!.severity).toBe('error');
+      expect(dictionary.components['Extras']!.members).toEqual([]);
+    });
+
+    it('skips a component-targeted append duplicating a field of a referencing scope', () => {
+      const shared = base();
+      shared.components['Extras'] = { name: 'Extras', members: [] };
+      shared.messages[1]!.members.splice(2, 0, { kind: 'component', name: 'Extras', reqd: 'N' });
+      // Quote carries Text (58) directly; adding it to Extras would double-emit it there.
+      const { dictionary, issues } = extendDictionary(shared, {
+        components: { Extras: { append: ['Text'] } },
+      });
+      expect(byCode(issues, 'extend/duplicate-member')!.severity).toBe('warning');
+      expect(dictionary.components['Extras']!.members).toEqual([]);
+    });
+
+    it('looks through optional members when finding the open group (backward)', () => {
+      // SecurityList body: [Header, 320(N), SecListGrp, Trailer] — 320 is optional, the
+      // group inside SecListGrp is the latest guaranteed wire content before the trailer.
+      const { dictionary, issues } = extendDictionary(base(), {
+        messages: { SecurityList: { append: ['Symbol'] } }, // 55 ∈ the group's scope
+      });
+      expect(byCode(issues, 'extend/ambiguous-boundary')!.severity).toBe('error');
+      expect(dictionary.messages[0]!.members).toHaveLength(base().messages[0]!.members.length);
+
+      // A REQUIRED field between the group and the insertion point seals the context:
+      const sealed = base();
+      sealed.messages[0]!.members.splice(3, 0, { kind: 'field', tag: 58, reqd: 'Y' });
+      const ok = extendDictionary(sealed, {
+        messages: { SecurityList: { append: ['Symbol'] } },
+      });
+      expect(errors(ok.issues)).toEqual([]);
+      const members = ok.dictionary.messages[0]!.members;
+      expect(members[members.length - 2]).toEqual({ kind: 'field', tag: 55, reqd: 'N' });
+    });
+
+    it('rejects a placed group that would capture wire members following it (forward)', () => {
+      // Insert a group containing Text (58) right after Instrument in Quote — the
+      // pre-existing optional 58 that follows would re-parse INTO the new group.
+      const { dictionary, issues } = extendDictionary(base(), {
+        fields: {
+          NoVenueAttrs: { tag: 5001, type: 'NumInGroup' },
+          VenueAttr: { tag: 5002, type: 'String' },
+        },
+        messages: {
+          Quote: {
+            append: [{ group: 'NoVenueAttrs', members: ['VenueAttr', 'Text'] }],
+            after: 'Instrument',
+          },
+        },
+      });
+      expect(byCode(issues, 'extend/ambiguous-boundary')!.severity).toBe('error');
+      expect(dictionary.messages[1]!.members).toHaveLength(base().messages[1]!.members.length);
+
+      // Anchored past the conflicting member, the same group is fine:
+      const ok = extendDictionary(base(), {
+        fields: {
+          NoVenueAttrs: { tag: 5001, type: 'NumInGroup' },
+          VenueAttr: { tag: 5002, type: 'String' },
+        },
+        messages: {
+          Quote: {
+            append: [{ group: 'NoVenueAttrs', members: ['VenueAttr', 'Text'] }],
+            after: 'Text',
+          },
+        },
+      });
+      expect(errors(ok.issues)).toEqual([]);
+    });
+
+    it('suppresses delimiter-defined when the placement is reverted by a shift', () => {
+      const tricky = base();
+      tricky.fields[999] = { tag: 999, name: 'NoThings', type: 'NumInGroup', isGroupCounter: true };
+      tricky.fields[998] = { tag: 998, name: 'NoStubs', type: 'NumInGroup', isGroupCounter: true };
+      tricky.components['EmptyLead'] = { name: 'EmptyLead', members: [] };
+      tricky.messages[1]!.members.splice(
+        2,
+        0,
+        {
+          kind: 'group',
+          counterTag: 999,
+          reqd: 'N',
+          members: [
+            { kind: 'component', name: 'EmptyLead', reqd: 'N' },
+            { kind: 'field', tag: 58, reqd: 'Y' },
+          ],
+        },
+        {
+          kind: 'group',
+          counterTag: 998,
+          reqd: 'N',
+          members: [{ kind: 'component', name: 'EmptyLead', reqd: 'N' }],
+        },
+      );
+      const { dictionary, issues } = extendDictionary(tricky, {
+        fields: { SymbolName: { tag: 5001, type: 'String' } },
+        components: { EmptyLead: { append: ['SymbolName'] } },
+      });
+      // Group 999's delimiter would shift 58 -> 5001: reverted; and although group 998's
+      // delimiter would have become defined, that observation must not survive the revert.
+      expect(byCode(issues, 'extend/group-delimiter-shift')!.severity).toBe('error');
+      expect(byCode(issues, 'extend/delimiter-defined')).toBeUndefined();
+      expect(dictionary.components['EmptyLead']!.members).toEqual([]);
+    });
+
+    it('warns when a data field is placed without its Length companion before it', () => {
+      const unwired = extendDictionary(base(), {
+        fields: {
+          VenueBlobLen: { tag: 5001, type: 'int' },
+          VenueBlob: { tag: 5002, type: 'data', lengthField: 5001 },
+        },
+        messages: { Quote: { append: ['VenueBlob'] } },
+      });
+      expect(byCode(unwired.issues, 'extend/data-length-not-placed')!.severity).toBe('warning');
+
+      const wired = extendDictionary(base(), {
+        fields: {
+          VenueBlobLen: { tag: 5001, type: 'int' },
+          VenueBlob: { tag: 5002, type: 'data', lengthField: 5001 },
+        },
+        messages: { Quote: { append: ['VenueBlobLen', 'VenueBlob'] } },
+      });
+      expect(byCode(wired.issues, 'extend/data-length-not-placed')).toBeUndefined();
+    });
+
+    it('warns when a NumInGroup counter is placed as a plain scalar member', () => {
+      const { issues } = extendDictionary(base(), {
+        fields: { NoVenueThings: { tag: 5001, type: 'NumInGroup' } },
+        messages: { Quote: { append: ['NoVenueThings'] } },
+      });
+      const warned = byCode(issues, 'extend/counter-as-field')!;
+      expect(warned.severity).toBe('warning');
+      expect(warned.refTagID).toBe(5001);
+    });
+  });
+});

--- a/packages/fix/src/dictionary/extendDictionary.ts
+++ b/packages/fix/src/dictionary/extendDictionary.ts
@@ -1,0 +1,1612 @@
+import { type FixIssue, issue } from '../errors';
+import type {
+  ComponentDef,
+  DictionaryJSON,
+  EnumValue,
+  FieldDef,
+  GroupMember,
+  MemberRef,
+  MessageDef,
+} from './types';
+import type {
+  ComponentExtension,
+  DictionaryExtension,
+  ExtensionEnumValue,
+  ExtensionFieldDef,
+  GroupExtension,
+  MemberSpec,
+  MessageExtension,
+  NewMessageSpec,
+} from './extension';
+
+/** The result of {@link extendDictionary}: the merged dictionary plus diagnostics. */
+export interface ExtendResult {
+  /**
+   * A fresh {@link DictionaryJSON} (deep clone — the base and the extensions are never
+   * mutated), consumed unchanged by `loadDictionary`/`createFixEngine`. When the base
+   * passes `validateDictionary` and {@link issues} carries no error-severity entries,
+   * the result passes `validateDictionary` too.
+   */
+  dictionary: DictionaryJSON;
+  /**
+   * `extend/*` diagnostics, returned as data — never thrown. Severity encodes the
+   * outcome: `error` = the operation was skipped or reverted, `warning` = applied (or,
+   * for `extend/duplicate-member`, already satisfied) but review, `info` = advisory.
+   */
+  issues: FixIssue[];
+}
+
+/**
+ * Apply venue extension declarations to a dictionary, producing a NEW
+ * {@link DictionaryJSON} the engine consumes unchanged. **Never throws** on data
+ * problems — every collision, unresolvable reference, malformed entry, or unsafe
+ * placement is a returned {@link FixIssue} (`extend/*` codes), and the offending
+ * operation is skipped or reverted rather than applied unsafely.
+ *
+ * Semantics:
+ * - **Pure**: inputs are never mutated; the result is deterministic.
+ * - **Composable**: extensions apply left to right; later extensions see earlier ones.
+ * - **Idempotent**: re-applying an extension changes nothing (duplicate members are
+ *   skipped with a warning; identical field redefinitions are silent).
+ * - **Delimiter-safe**: placements are append/after-anchor only, and every operation is
+ *   checked against the corruption hazards the grammar alone cannot rule out — a group
+ *   entry delimiter shifting (`extend/group-delimiter-shift`, reverted), a placed member
+ *   colliding with a group scope that could be open on the wire around the insertion
+ *   point in either direction (`extend/ambiguous-boundary`, skipped; optional members
+ *   between are treated as potentially absent), a new group with no resolvable entry
+ *   delimiter (`extend/unresolvable-group-delimiter`, skipped), and a component
+ *   reference cycle (`extend/component-cycle`, reverted).
+ *
+ * Run `validateDictionary` on the result as the final gate, exactly as for any other
+ * dictionary.
+ *
+ * ```ts
+ * const { dictionary, issues } = extendDictionary(fix44, ctrader);
+ * if (issues.some((i) => i.severity === 'error')) {
+ *   // an operation was skipped or reverted — fix the extension declaration
+ * }
+ * const engine = createFixEngine(dictionary);
+ * ```
+ */
+export function extendDictionary(
+  base: DictionaryJSON,
+  ...extensions: DictionaryExtension[]
+): ExtendResult {
+  const dictionary = structuredClone(base);
+  const issues: FixIssue[] = [];
+  for (const ext of extensions) {
+    if (isPlainObject(ext)) {
+      applyExtension(dictionary, ext, issues);
+    }
+  }
+  return { dictionary, issues };
+}
+
+// --- application ------------------------------------------------------------------------
+
+/** Shared state for one extension application. */
+interface Ctx {
+  d: DictionaryJSON;
+  fieldsByName: Map<string, FieldDef>;
+  issues: FixIssue[];
+  /** Issue-path prefix, `"<id>:"` when the extension carries an id. */
+  prefix: string;
+}
+
+function applyExtension(d: DictionaryJSON, ext: DictionaryExtension, issues: FixIssue[]): void {
+  const ctx: Ctx = {
+    d,
+    fieldsByName: new Map(Object.values(d.fields ?? {}).map((f) => [f.name, f])),
+    issues,
+    prefix: typeof ext.id === 'string' && ext.id !== '' ? `${ext.id}:` : '',
+  };
+  applyFields(ctx, ext.fields);
+  applyEnums(ctx, ext.enums);
+  applyComponents(ctx, ext.components);
+  applyMessages(ctx, ext.messages);
+  if (typeof ext.id === 'string' && ext.id !== '' && !(d.extensions ?? []).includes(ext.id)) {
+    (d.extensions ??= []).push(ext.id);
+  }
+}
+
+function invalidSpec(ctx: Ctx, path: string, what: string): void {
+  ctx.issues.push(
+    issue(
+      'extend/invalid-spec',
+      `${what} at "${path}" is structurally malformed; the entry is skipped.`,
+      { path },
+    ),
+  );
+}
+
+// --- fields -------------------------------------------------------------------------------
+
+function applyFields(ctx: Ctx, fields: DictionaryExtension['fields']): void {
+  for (const [name, def] of Object.entries(fields ?? {})) {
+    if (!isPlainObject(def)) {
+      invalidSpec(ctx, `${ctx.prefix}${name}`, 'Field definition');
+      continue;
+    }
+    applyField(ctx, name, def);
+  }
+}
+
+function applyField(ctx: Ctx, name: string, def: ExtensionFieldDef): void {
+  const path = `${ctx.prefix}${name}`;
+  if (!Number.isInteger(def.tag) || def.tag <= 0) {
+    ctx.issues.push(
+      issue(
+        'extend/field-bad-tag',
+        `Field "${name}" has tag ${def.tag}, which is not a positive integer; the field is skipped.`,
+        { path },
+      ),
+    );
+    return;
+  }
+  if (typeof def.type !== 'string' || !hasOwn(ctx.d.datatypes ?? {}, def.type)) {
+    ctx.issues.push(
+      issue(
+        'extend/field-unknown-type',
+        `Field "${name}" (${def.tag}) uses datatype "${def.type}", which is not defined in the dictionary; the field is skipped.`,
+        { path, refTagID: def.tag },
+      ),
+    );
+    return;
+  }
+  const sameName = ctx.fieldsByName.get(name);
+  if (sameName && sameName.tag !== def.tag) {
+    ctx.issues.push(
+      issue(
+        'extend/field-name-collision',
+        `Field name "${name}" is already bound to tag ${sameName.tag}; the extension field (${def.tag}) is skipped — pick a unique name or redefine tag ${sameName.tag} itself.`,
+        { path, refTagID: def.tag },
+      ),
+    );
+    return;
+  }
+
+  const fieldDef: FieldDef = { tag: def.tag, name, type: def.type };
+  if (def.enumValues !== undefined && Array.isArray(def.enumValues)) {
+    fieldDef.enumValues = def.enumValues.filter(isEnumValueSpec).map(toEnumValue);
+  }
+  if (derivesFrom(ctx.d, def.type, 'NumInGroup')) {
+    fieldDef.isGroupCounter = true;
+  }
+  if (def.lengthField !== undefined) {
+    fieldDef.lengthField = def.lengthField;
+  }
+  if (def.description !== undefined) {
+    fieldDef.description = def.description;
+  }
+
+  const existing = ctx.d.fields[def.tag];
+  if (existing && !deepEqual(existing, fieldDef)) {
+    ctx.issues.push(
+      issue(
+        'extend/field-tag-collision',
+        `Tag ${def.tag} is already defined as "${existing.name}" (${existing.type}); the extension definition "${name}" (${def.type}) replaces it.`,
+        { severity: 'warning', path, refTagID: def.tag },
+      ),
+    );
+  }
+  if (existing && existing.name !== name) {
+    ctx.fieldsByName.delete(existing.name);
+  }
+
+  const inUserRange = (def.tag >= 5000 && def.tag <= 9999) || def.tag >= 20000;
+  if (!existing && !inUserRange) {
+    ctx.issues.push(
+      issue(
+        'extend/tag-outside-user-range',
+        `Tag ${def.tag} ("${name}") lies outside the FIX user-defined ranges (5000-9999, 20000+); it may collide with standard tags of other FIX versions.`,
+        { severity: 'info', path, refTagID: def.tag },
+      ),
+    );
+  }
+  if (ctx.d.datatypes[def.type]?.base === 'data' && def.lengthField === undefined) {
+    ctx.issues.push(
+      issue(
+        'extend/data-length-unwired',
+        `Field "${name}" (${def.tag}) is a data field with no lengthField; a value embedding the separator cannot be scanned safely.`,
+        { severity: 'warning', path, refTagID: def.tag },
+      ),
+    );
+  }
+
+  ctx.d.fields[def.tag] = fieldDef;
+  ctx.fieldsByName.set(name, fieldDef);
+}
+
+// --- enums --------------------------------------------------------------------------------
+
+function applyEnums(ctx: Ctx, enums: DictionaryExtension['enums']): void {
+  for (const [fieldName, values] of Object.entries(enums ?? {})) {
+    const path = `${ctx.prefix}${fieldName}`;
+    if (!Array.isArray(values)) {
+      invalidSpec(ctx, path, 'Enum value list');
+      continue;
+    }
+    const field = ctx.fieldsByName.get(fieldName);
+    if (!field) {
+      ctx.issues.push(
+        issue(
+          'extend/enum-unknown-field',
+          `Enum values target field "${fieldName}", which is not defined in the dictionary; the entry is skipped.`,
+          { path },
+        ),
+      );
+      continue;
+    }
+    const list = (field.enumValues ??= []);
+    for (const v of values) {
+      if (!isEnumValueSpec(v)) {
+        invalidSpec(ctx, path, 'Enum value');
+        continue;
+      }
+      const existing = list.findIndex((e) => e.value === v.value);
+      if (existing === -1) {
+        list.push(toEnumValue(v));
+        continue;
+      }
+      if (list[existing]!.name === v.name) {
+        continue; // identical value+name: silent, keeps re-application idempotent
+      }
+      ctx.issues.push(
+        issue(
+          'extend/enum-value-conflict',
+          `Enum value "${v.value}" of ${fieldName} (${field.tag}) is already defined as "${list[existing]!.name}"; the extension entry "${v.name}" replaces it.`,
+          { severity: 'warning', path, refTagID: field.tag },
+        ),
+      );
+      list[existing] = toEnumValue(v);
+    }
+  }
+}
+
+function isEnumValueSpec(v: unknown): v is ExtensionEnumValue {
+  return (
+    isPlainObject(v) &&
+    typeof (v as ExtensionEnumValue).value === 'string' &&
+    typeof (v as ExtensionEnumValue).name === 'string'
+  );
+}
+
+function toEnumValue(v: ExtensionEnumValue): EnumValue {
+  return { value: v.value, name: v.name, description: v.description ?? v.name };
+}
+
+// --- components ---------------------------------------------------------------------------
+
+function applyComponents(ctx: Ctx, components: DictionaryExtension['components']): void {
+  const entries = Object.entries(components ?? {}).filter(([name, spec]) => {
+    if (isPlainObject(spec)) {
+      return true;
+    }
+    invalidSpec(ctx, `${ctx.prefix}${name}`, 'Component entry');
+    return false;
+  });
+
+  // New components register in one pass before their members resolve, so new components
+  // may reference each other regardless of declaration order.
+  const pending: [string, readonly MemberSpec[]][] = [];
+  for (const [name, spec] of entries) {
+    if (isNewComponent(spec)) {
+      if (hasOwn(ctx.d.components, name)) {
+        ctx.issues.push(
+          issue(
+            'extend/component-collision',
+            `Component "${name}" is already defined; the new definition is skipped — extend the existing component with the append form instead.`,
+            { path: `${ctx.prefix}${name}` },
+          ),
+        );
+        continue;
+      }
+      ctx.d.components[name] = { name, members: [] };
+      pending.push([name, spec.members]);
+    }
+  }
+  for (const [name, members] of pending) {
+    const refs = Array.isArray(members)
+      ? resolveSpecs(ctx, members, `${ctx.prefix}${name}`)
+      : undefined;
+    if (!refs) {
+      if (!Array.isArray(members)) {
+        invalidSpec(ctx, `${ctx.prefix}${name}`, 'Component members');
+      }
+      delete ctx.d.components[name]; // unresolvable member: the whole definition is skipped
+      continue;
+    }
+    ctx.d.components[name]!.members = refs;
+  }
+
+  // A skipped definition can leave dangling references in sibling NEW components, and
+  // new components can reference each other in a cycle the runtime cannot expand. Both
+  // would escape as error-severity dict/* findings, so delete offenders to a fixpoint.
+  let changed = true;
+  while (changed) {
+    changed = false;
+    for (const [name] of pending) {
+      const component = hasOwn(ctx.d.components, name) ? ctx.d.components[name] : undefined;
+      if (!component) {
+        continue;
+      }
+      const dangling = component.members.find(
+        (m) => m.kind === 'component' && !hasOwn(ctx.d.components, m.name),
+      );
+      if (dangling) {
+        ctx.issues.push(
+          issue(
+            'extend/unknown-member',
+            `Component "${name}" references component "${(dangling as { name: string }).name}", whose definition was skipped; "${name}" is skipped too.`,
+            { path: `${ctx.prefix}${name}` },
+          ),
+        );
+        delete ctx.d.components[name];
+        changed = true;
+        continue;
+      }
+      if (componentExpansionContains(ctx.d, name, name)) {
+        ctx.issues.push(
+          issue(
+            'extend/component-cycle',
+            `Component "${name}" participates in a component reference cycle, which the runtime cannot expand; the definition is skipped.`,
+            { path: `${ctx.prefix}${name}` },
+          ),
+        );
+        delete ctx.d.components[name];
+        changed = true;
+      }
+    }
+  }
+
+  for (const [name, spec] of entries) {
+    if (!isNewComponent(spec)) {
+      applyComponentPatch(ctx, name, spec);
+    }
+  }
+}
+
+function isNewComponent(
+  spec: ComponentExtension,
+): spec is { readonly members: readonly MemberSpec[] } {
+  return 'members' in spec;
+}
+
+function applyComponentPatch(
+  ctx: Ctx,
+  name: string,
+  spec: Exclude<ComponentExtension, { members: readonly MemberSpec[] }>,
+): void {
+  const path = `${ctx.prefix}${name}`;
+  const component: ComponentDef | undefined = hasOwn(ctx.d.components, name)
+    ? ctx.d.components[name]
+    : undefined;
+  if (!component) {
+    ctx.issues.push(
+      issue(
+        'extend/target-not-found',
+        `Component "${name}" is not defined in the dictionary; the placement is skipped.`,
+        { path },
+      ),
+    );
+    return;
+  }
+  const reached = messagesReaching(ctx.d, name);
+  ctx.issues.push(
+    issue(
+      'extend/component-fanout',
+      `Placement targets component "${name}", which ${reached.length === 1 ? `is reached by 1 message (${reached[0]})` : `is reached by ${reached.length} messages${reached.length > 0 ? ` (${reached.join(', ')})` : ''}`}; the added members become visible in every referencing scope.`,
+      { severity: 'info', path },
+    ),
+  );
+  applyBodyExtension(ctx, component.members, spec, path);
+}
+
+// --- messages -----------------------------------------------------------------------------
+
+function applyMessages(ctx: Ctx, messages: DictionaryExtension['messages']): void {
+  for (const [name, spec] of Object.entries(messages ?? {})) {
+    if (!isPlainObject(spec)) {
+      invalidSpec(ctx, `${ctx.prefix}${name}`, 'Message entry');
+      continue;
+    }
+    if ('msgType' in spec && spec.msgType !== undefined) {
+      if (typeof spec.msgType !== 'string' || !Array.isArray((spec as NewMessageSpec).members)) {
+        invalidSpec(
+          ctx,
+          `${ctx.prefix}${name}`,
+          'New message spec (msgType must be a string and members an array)',
+        );
+        continue;
+      }
+      applyNewMessage(ctx, name, spec as NewMessageSpec);
+    } else {
+      applyMessagePatch(ctx, name, spec);
+    }
+  }
+}
+
+function applyNewMessage(ctx: Ctx, name: string, spec: NewMessageSpec): void {
+  const path = `${ctx.prefix}${name}`;
+  const body = resolveSpecs(ctx, spec.members, path);
+  if (!body) {
+    return; // unresolvable member: the whole message is skipped (errors already reported)
+  }
+
+  const members: MemberRef[] = body;
+  const { header, trailer } = detectHeaderTrailer(ctx.d);
+  const injected: string[] = [];
+  if (header && !members.some((m) => m.kind === 'component' && m.name === header)) {
+    members.unshift({ kind: 'component', name: header, reqd: 'Y' });
+    injected.push(header);
+  }
+  if (trailer && !members.some((m) => m.kind === 'component' && m.name === trailer)) {
+    members.push({ kind: 'component', name: trailer, reqd: 'Y' });
+    injected.push(trailer);
+  }
+  if (injected.length > 0) {
+    ctx.issues.push(
+      issue(
+        'extend/header-trailer-injected',
+        `Message "${name}" (${spec.msgType}) was wrapped with the dictionary's ${injected.map((c) => `"${c}"`).join(' and ')}.`,
+        { severity: 'info', path, refMsgType: spec.msgType },
+      ),
+    );
+  }
+  if (!header || !trailer) {
+    ctx.issues.push(
+      issue(
+        'extend/header-trailer-missing',
+        `No standard ${!header && !trailer ? 'header or trailer' : !header ? 'header' : 'trailer'} component could be detected in the dictionary; message "${name}" (${spec.msgType}) is applied without it — encode will silently drop session fields unless the body carries them.`,
+        { severity: 'warning', path, refMsgType: spec.msgType },
+      ),
+    );
+  }
+
+  const message: MessageDef = {
+    name,
+    msgType: spec.msgType,
+    category: spec.category === 'admin' ? 'admin' : 'app',
+    members,
+  };
+
+  const existingIndex = ctx.d.messages.findIndex((m) => m.msgType === spec.msgType);
+  if (ctx.d.messages.some((m, i) => m.name === name && i !== existingIndex)) {
+    ctx.issues.push(
+      issue(
+        'extend/message-name-collision',
+        `Message name "${name}" is already used by another message with a different MsgType; both are kept (names stop being unique).`,
+        { severity: 'warning', path, refMsgType: spec.msgType },
+      ),
+    );
+  }
+  if (existingIndex !== -1) {
+    ctx.issues.push(
+      issue(
+        'extend/msgtype-collision',
+        `MsgType "${spec.msgType}" is already defined as "${ctx.d.messages[existingIndex]!.name}"; the extension message "${name}" replaces it in place.`,
+        { severity: 'warning', path, refMsgType: spec.msgType },
+      ),
+    );
+    ctx.d.messages[existingIndex] = message;
+  } else {
+    ctx.d.messages.push(message);
+  }
+}
+
+function applyMessagePatch(ctx: Ctx, name: string, spec: MessageExtension): void {
+  const path = `${ctx.prefix}${name}`;
+  const matches = ctx.d.messages.filter((m) => m.name === name);
+  if (matches.length === 0) {
+    ctx.issues.push(
+      issue(
+        'extend/target-not-found',
+        `Message "${name}" is not defined in the dictionary; the placement is skipped.`,
+        { path },
+      ),
+    );
+    return;
+  }
+  if (matches.length > 1) {
+    ctx.issues.push(
+      issue(
+        'extend/target-not-found',
+        `Message name "${name}" is ambiguous (${matches.length} messages carry it: ${matches.map((m) => m.msgType).join(', ')}); the placement is skipped.`,
+        { path },
+      ),
+    );
+    return;
+  }
+  applyBodyExtension(ctx, matches[0]!.members, spec, path);
+}
+
+/** Detect the standard header/trailer component names by vote across the messages. */
+function detectHeaderTrailer(d: DictionaryJSON): { header?: string; trailer?: string } {
+  let header: string | null | undefined;
+  let trailer: string | null | undefined;
+  for (const message of d.messages) {
+    const first = message.members[0];
+    if (first?.kind === 'component') {
+      const tags = componentDirectTags(d, first.name);
+      if (tags.has(49) || tags.has(34)) {
+        header = header === undefined || header === first.name ? first.name : null;
+      }
+    }
+    const last = message.members[message.members.length - 1];
+    if (last?.kind === 'component' && componentDirectTags(d, last.name).has(10)) {
+      trailer = trailer === undefined || trailer === last.name ? last.name : null;
+    }
+  }
+  return { header: header ?? undefined, trailer: trailer ?? undefined };
+}
+
+// --- shared placement pipeline --------------------------------------------------------------
+
+/** Apply a body-level patch (append and/or group additions) to a message or component. */
+function applyBodyExtension(
+  ctx: Ctx,
+  body: MemberRef[],
+  spec: {
+    append?: readonly MemberSpec[];
+    after?: string;
+    groups?: Readonly<Record<string, GroupExtension>>;
+  },
+  path: string,
+): void {
+  if (spec.append !== undefined) {
+    if (Array.isArray(spec.append)) {
+      applyPlacement(ctx, body, spec.append, spec.after, path);
+    } else {
+      invalidSpec(ctx, path, 'Append list');
+    }
+  }
+  if (spec.groups !== undefined && !isPlainObject(spec.groups)) {
+    invalidSpec(ctx, path, 'Group patch record');
+    return;
+  }
+  for (const [groupPath, groupExt] of Object.entries(spec.groups ?? {})) {
+    const fullPath = `${path}.${groupPath}`;
+    if (!isPlainObject(groupExt) || !Array.isArray(groupExt.append)) {
+      invalidSpec(ctx, fullPath, 'Group patch');
+      continue;
+    }
+    const group = resolveGroupPath(ctx, body, groupPath.split('.'), fullPath);
+    if (group) {
+      applyPlacement(ctx, group.members, groupExt.append, groupExt.after, fullPath);
+    }
+  }
+}
+
+/**
+ * The placement pipeline: resolve → anchor → duplicate guard → backward boundary check →
+ * insert → forward boundary check → component-cycle check → delimiter post-check (with
+ * revert) → data-length adjacency check. Member-resolution failures skip the whole
+ * placement; duplicate and boundary hits skip the individual member.
+ */
+function applyPlacement(
+  ctx: Ctx,
+  body: MemberRef[],
+  specs: readonly MemberSpec[],
+  after: string | undefined,
+  path: string,
+): void {
+  const refs = resolveSpecs(ctx, specs, path);
+  if (!refs) {
+    return;
+  }
+
+  const owner = bodyOwner(ctx.d, body);
+  let insertAt: number;
+  if (after !== undefined) {
+    const anchor = findMemberIndex(ctx, body, after);
+    if (anchor === -1) {
+      ctx.issues.push(
+        issue(
+          'extend/member-not-found',
+          `Anchor "${after}" matches no member of the target body; the placement is skipped.`,
+          { path },
+        ),
+      );
+      return;
+    }
+    insertAt = anchor + 1;
+  } else if (owner?.kind === 'message') {
+    insertAt = beforeTrailerIndex(ctx.d, body);
+  } else {
+    insertAt = body.length;
+  }
+
+  // Duplicates are judged against the target scope AND — when the target is a shared
+  // component's own body — against every scope that references it, since the added
+  // member becomes part of each of those scopes on the wire.
+  const duplicateScopes: MemberRef[][] = [body];
+  if (owner?.kind === 'component') {
+    for (const site of componentSites(ctx.d, owner.name)) {
+      duplicateScopes.push(site.parent);
+    }
+  }
+
+  const delimitersBefore = collectGroupDelimiters(ctx.d);
+  const inserted: MemberRef[] = [];
+  for (const ref of refs) {
+    if (duplicateScopes.some((scope) => hasMemberIdentity(ctx, scope, ref))) {
+      ctx.issues.push(
+        issue(
+          'extend/duplicate-member',
+          `${describeRef(ctx, ref)} is already part of the target scope; it is not added again.`,
+          { severity: 'warning', path, ...refTag(ref) },
+        ),
+      );
+      continue;
+    }
+    const hazard = backwardHazard(ctx, body, insertAt, ref);
+    if (hazard !== undefined) {
+      ctx.issues.push(
+        issue(
+          'extend/ambiguous-boundary',
+          `${describeRef(ctx, ref)} could sit right after entries of the repeating group headed by ${fieldLabel(ctx, hazard.counterTag)}, whose scope also contains it — on re-parse the value would land inside that group. Anchor it with \`after\` ahead of the group, or place it inside the group instead.`,
+          { path, ...refTag(ref) },
+        ),
+      );
+      continue;
+    }
+    body.splice(insertAt, 0, ref);
+    inserted.push(ref);
+    insertAt += 1;
+  }
+
+  // Forward pass: a placed member that OPENS a scope (a group, or a component ending in
+  // one) must not capture the wire members that can follow it.
+  for (const ref of [...inserted]) {
+    const open = placedOpenGroups(ctx.d, ref);
+    if (open.length === 0) {
+      continue;
+    }
+    const at = body.indexOf(ref);
+    const following = forwardHazardTags(ctx.d, body, at + 1);
+    const capturing = open.find((group) => {
+      const scope = expandedScope(ctx.d, group.members).tags;
+      const delimiter = firstWireTag(ctx.d, group.members, new Set());
+      return [...following].some((tag) => scope.has(tag) || tag === delimiter);
+    });
+    if (capturing) {
+      body.splice(body.indexOf(ref), 1);
+      inserted.splice(inserted.indexOf(ref), 1);
+      ctx.issues.push(
+        issue(
+          'extend/ambiguous-boundary',
+          `${describeRef(ctx, ref)} opens the repeating group headed by ${fieldLabel(ctx, capturing.counterTag)}, whose scope also contains wire members that can follow the insertion point — on re-parse they would land inside the group. Place it where nothing in its scope can follow.`,
+          { path, ...refTag(ref) },
+        ),
+      );
+    }
+  }
+
+  // A placed component reference must not close a cycle over the component that owns the
+  // target body (directly or through the group nesting).
+  const owningComp = owningComponentName(ctx.d, body);
+  if (owningComp !== undefined) {
+    for (const ref of [...inserted]) {
+      if (ref.kind === 'component' && componentExpansionContains(ctx.d, ref.name, owningComp)) {
+        body.splice(body.indexOf(ref), 1);
+        inserted.splice(inserted.indexOf(ref), 1);
+        ctx.issues.push(
+          issue(
+            'extend/component-cycle',
+            `Placing component "${ref.name}" here would create a component reference cycle through "${owningComp}"; the member is skipped.`,
+            { path },
+          ),
+        );
+      }
+    }
+  }
+
+  if (inserted.length === 0) {
+    return;
+  }
+
+  // Delimiter post-check across the WHOLE dictionary: an append can shift a group's
+  // delimiter transitively (a group whose leading component previously resolved to no
+  // field). A shifted delimiter breaks entry detection for already-recorded traffic, so
+  // the whole placement is reverted. `delimiter-defined` observations are buffered and
+  // reported only when the placement stands.
+  const delimitersAfter = collectGroupDelimiters(ctx.d);
+  const shifted: GroupMember[] = [];
+  const defined: FixIssue[] = [];
+  for (const [group, before] of delimitersBefore) {
+    const now = delimitersAfter.get(group);
+    if (before !== undefined && now !== before) {
+      shifted.push(group);
+    } else if (before === undefined && now !== undefined) {
+      defined.push(
+        issue(
+          'extend/delimiter-defined',
+          `The repeating group headed by ${fieldLabel(ctx, group.counterTag)} previously had no resolvable entry delimiter; it is now ${fieldLabel(ctx, now)}.`,
+          { severity: 'info', path, refTagID: group.counterTag },
+        ),
+      );
+    }
+  }
+  if (shifted.length > 0) {
+    for (const ref of inserted) {
+      const at = body.indexOf(ref);
+      if (at !== -1) {
+        body.splice(at, 1);
+      }
+    }
+    ctx.issues.push(
+      issue(
+        'extend/group-delimiter-shift',
+        `The placement would change the entry delimiter of the repeating group${shifted.length > 1 ? 's' : ''} headed by ${shifted.map((g) => fieldLabel(ctx, g.counterTag)).join(', ')}, breaking entry detection; the placement is reverted.`,
+        { path },
+      ),
+    );
+    return;
+  }
+  ctx.issues.push(...defined);
+
+  // A data field must be preceded by its Length companion in the same body, or encode
+  // will drop the caller-supplied length and SOH-embedding values corrupt the frame.
+  for (const ref of inserted) {
+    if (ref.kind !== 'field') {
+      continue;
+    }
+    const lengthField = ctx.d.fields[ref.tag]?.lengthField;
+    if (lengthField === undefined) {
+      continue;
+    }
+    const at = body.indexOf(ref);
+    if (!expandedScope(ctx.d, body.slice(0, at)).tags.has(lengthField)) {
+      ctx.issues.push(
+        issue(
+          'extend/data-length-not-placed',
+          `Data field ${fieldLabel(ctx, ref.tag)} was placed without its Length companion ${fieldLabel(ctx, lengthField)} positioned before it in the same body; encode cannot emit the length, and a value embedding the separator would corrupt the frame.`,
+          { severity: 'warning', path, refTagID: ref.tag },
+        ),
+      );
+    }
+  }
+}
+
+// --- member-spec resolution -----------------------------------------------------------------
+
+/**
+ * Resolve MemberSpecs to MemberRefs. Returns `undefined` (after reporting each failure)
+ * when ANY spec is unresolvable — placements are atomic so a half-applied member list
+ * never silently changes meaning.
+ */
+function resolveSpecs(
+  ctx: Ctx,
+  specs: readonly MemberSpec[],
+  path: string,
+): MemberRef[] | undefined {
+  const refs: MemberRef[] = [];
+  let failed = false;
+  for (const spec of specs) {
+    const ref = resolveSpec(ctx, spec, path);
+    if (ref) {
+      refs.push(ref);
+    } else {
+      failed = true;
+    }
+  }
+  return failed ? undefined : refs;
+}
+
+function resolveSpec(ctx: Ctx, spec: MemberSpec, path: string): MemberRef | undefined {
+  if (typeof spec !== 'string' && !isPlainObject(spec)) {
+    invalidSpec(ctx, path, 'Member spec');
+    return undefined;
+  }
+  const normalized = typeof spec === 'string' ? { field: spec } : spec;
+
+  if ('field' in normalized) {
+    const field = ctx.fieldsByName.get(normalized.field);
+    if (!field) {
+      ctx.issues.push(
+        issue(
+          'extend/unknown-member',
+          `Member "${normalized.field}" names no field in the dictionary or the extension; the placement is skipped.`,
+          { path },
+        ),
+      );
+      return undefined;
+    }
+    if (derivesFrom(ctx.d, field.type, 'NumInGroup')) {
+      ctx.issues.push(
+        issue(
+          'extend/counter-as-field',
+          `Field ${field.name} (${field.tag}) is a NumInGroup counter but was placed as a plain scalar member; on the wire it heads a repeating group, so real traffic would mis-parse — use the { group: '${field.name}', members: [...] } form instead.`,
+          { severity: 'warning', path, refTagID: field.tag },
+        ),
+      );
+    }
+    return { kind: 'field', tag: field.tag, reqd: normalized.reqd ?? 'N' };
+  }
+
+  if ('component' in normalized) {
+    if (!hasOwn(ctx.d.components, normalized.component)) {
+      ctx.issues.push(
+        issue(
+          'extend/unknown-member',
+          `Member component "${normalized.component}" is not defined in the dictionary or the extension; the placement is skipped.`,
+          { path },
+        ),
+      );
+      return undefined;
+    }
+    return { kind: 'component', name: normalized.component, reqd: normalized.reqd ?? 'N' };
+  }
+
+  if (!('group' in normalized)) {
+    invalidSpec(ctx, path, 'Member spec (expected a field/component/group form)');
+    return undefined;
+  }
+
+  const counter = ctx.fieldsByName.get(normalized.group);
+  if (!counter) {
+    ctx.issues.push(
+      issue(
+        'extend/unknown-member',
+        `Group counter "${normalized.group}" names no field in the dictionary or the extension; the placement is skipped.`,
+        { path },
+      ),
+    );
+    return undefined;
+  }
+  if (!derivesFrom(ctx.d, counter.type, 'NumInGroup')) {
+    ctx.issues.push(
+      issue(
+        'extend/counter-not-marked',
+        `Group counter ${counter.name} (${counter.tag}) has datatype "${counter.type}", which does not derive from NumInGroup; parse-time counter detection depends on it — fix the field's type.`,
+        { severity: 'warning', path, refTagID: counter.tag },
+      ),
+    );
+  }
+  if (!Array.isArray(normalized.members)) {
+    invalidSpec(ctx, `${path}.${normalized.group}`, 'Group members');
+    return undefined;
+  }
+  const members = resolveSpecs(ctx, normalized.members, `${path}.${normalized.group}`);
+  if (!members) {
+    return undefined;
+  }
+  if (members.length === 0 || firstWireTag(ctx.d, members, new Set()) === undefined) {
+    ctx.issues.push(
+      issue(
+        'extend/unresolvable-group-delimiter',
+        `The new repeating group headed by ${counter.name} (${counter.tag}) has a body that resolves to no leading wire field, so the parser would have no entry delimiter; the placement is skipped.`,
+        { path: `${path}.${normalized.group}`, refTagID: counter.tag },
+      ),
+    );
+    return undefined;
+  }
+  return { kind: 'group', counterTag: counter.tag, reqd: normalized.reqd ?? 'N', members };
+}
+
+// --- group-path resolution ------------------------------------------------------------------
+
+/**
+ * Resolve a dotted counter-field-name path to the repeating group it names, starting from
+ * a message or component body. Descends through a component reference only when the
+ * component is referenced exactly once in the whole dictionary — additions through a
+ * shared component must target the component explicitly, so the fan-out is a decision,
+ * not an accident.
+ */
+function resolveGroupPath(
+  ctx: Ctx,
+  body: MemberRef[],
+  segments: string[],
+  path: string,
+): GroupMember | undefined {
+  let scope = body;
+  let group: GroupMember | undefined;
+  for (const segment of segments) {
+    const counter = ctx.fieldsByName.get(segment);
+    if (!counter) {
+      ctx.issues.push(
+        issue(
+          'extend/target-not-found',
+          `Group path segment "${segment}" names no field in the dictionary; the placement is skipped.`,
+          { path },
+        ),
+      );
+      return undefined;
+    }
+    const found = findGroupInScope(ctx, scope, counter.tag);
+    if (found.kind === 'none') {
+      const hint =
+        found.behind.length > 0
+          ? ` The group exists behind shared component${found.behind.length > 1 ? 's' : ''} ${found.behind.map((c) => `"${c}" (reached by ${messagesReaching(ctx.d, c).length} message${messagesReaching(ctx.d, c).length === 1 ? '' : 's'})`).join(', ')} — target the component explicitly via the extension's \`components\` entry.`
+          : '';
+      ctx.issues.push(
+        issue(
+          'extend/target-not-found',
+          `Repeating group headed by ${counter.name} (${counter.tag}) was not found at "${path}".${hint}`,
+          { path, refTagID: counter.tag },
+        ),
+      );
+      return undefined;
+    }
+    if (found.kind === 'ambiguous') {
+      ctx.issues.push(
+        issue(
+          'extend/target-not-found',
+          `Group path segment "${segment}" is ambiguous at "${path}" (multiple occurrences); target the owning component explicitly.`,
+          { path, refTagID: counter.tag },
+        ),
+      );
+      return undefined;
+    }
+    if (found.via.length > 0) {
+      ctx.issues.push(
+        issue(
+          'extend/component-fanout',
+          `Group ${counter.name} (${counter.tag}) was reached through component${found.via.length > 1 ? 's' : ''} ${found.via.map((c) => `"${c}"`).join(', ')} (referenced only here); the addition modifies the component definition.`,
+          { severity: 'info', path, refTagID: counter.tag },
+        ),
+      );
+    }
+    group = found.group;
+    scope = found.group.members;
+  }
+  return group;
+}
+
+type GroupSearch =
+  | { kind: 'found'; group: GroupMember; via: string[] }
+  | { kind: 'ambiguous' }
+  | { kind: 'none'; behind: string[] };
+
+/**
+ * Find the group headed by `counterTag` in a body: directly among its members, or by
+ * descending through component references whose global reference count is exactly 1.
+ * Components referenced more than once are not descended into; when the group lives
+ * only behind such components, their names are returned for the error hint.
+ */
+function findGroupInScope(ctx: Ctx, body: MemberRef[], counterTag: number): GroupSearch {
+  const matches: { group: GroupMember; via: string[] }[] = [];
+  const behind: string[] = [];
+  search(body, [], new Set());
+
+  function search(members: MemberRef[], chain: string[], seen: Set<string>): void {
+    for (const member of members) {
+      if (member.kind === 'group' && member.counterTag === counterTag) {
+        matches.push({ group: member, via: chain });
+      } else if (member.kind === 'component' && !seen.has(member.name)) {
+        const component = hasOwn(ctx.d.components, member.name)
+          ? ctx.d.components[member.name]
+          : undefined;
+        if (!component) {
+          continue;
+        }
+        const next = new Set(seen);
+        next.add(member.name);
+        if (componentReferenceCount(ctx.d, member.name) === 1) {
+          search(component.members, [...chain, member.name], next);
+        } else if (containsGroup(ctx, component.members, counterTag, next)) {
+          behind.push(member.name);
+        }
+      }
+    }
+  }
+
+  if (matches.length === 1) {
+    return { kind: 'found', group: matches[0]!.group, via: matches[0]!.via };
+  }
+  if (matches.length > 1) {
+    return { kind: 'ambiguous' };
+  }
+  return { kind: 'none', behind };
+}
+
+/** Whether a body (expanded through components) contains a group headed by `counterTag`. */
+function containsGroup(
+  ctx: Ctx,
+  members: MemberRef[],
+  counterTag: number,
+  seen: Set<string>,
+): boolean {
+  for (const member of members) {
+    if (member.kind === 'group' && member.counterTag === counterTag) {
+      return true;
+    }
+    if (member.kind === 'component' && !seen.has(member.name)) {
+      seen.add(member.name);
+      const component = hasOwn(ctx.d.components, member.name)
+        ? ctx.d.components[member.name]
+        : undefined;
+      if (component && containsGroup(ctx, component.members, counterTag, seen)) {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+// --- placement safety checks ----------------------------------------------------------------
+
+/**
+ * The backward boundary hazard: a member placed at `insertAt` lands on the wire right
+ * after the entries of any repeating group that could still be "open" at that position.
+ * Members between the insertion point and an earlier group are walked as potentially
+ * absent when optional — only a required member guarantees a wire token that closes the
+ * group. When the target body belongs to a component, the context continues at every
+ * site referencing it; when it is a group entry body, the context wraps around to the
+ * previous entry of the same group.
+ *
+ * @returns the innermost hazardous group, or `undefined` when the placement is safe.
+ */
+function backwardHazard(
+  ctx: Ctx,
+  body: MemberRef[],
+  insertAt: number,
+  ref: MemberRef,
+): GroupMember | undefined {
+  const openGroups = openGroupsBefore(ctx.d, body, insertAt);
+  if (openGroups.length === 0) {
+    return undefined;
+  }
+  const introduced = introducedTags(ctx, ref);
+  for (const group of openGroups) {
+    const scope = expandedScope(ctx.d, group.members).tags;
+    const delimiter = firstWireTag(ctx.d, group.members, new Set());
+    for (const tag of introduced) {
+      if (scope.has(tag) || tag === delimiter) {
+        return group;
+      }
+    }
+  }
+  return undefined;
+}
+
+/** Every repeating group that could be open on the wire just before `upTo` in `body`. */
+function openGroupsBefore(d: DictionaryJSON, body: MemberRef[], upTo: number): GroupMember[] {
+  const out: GroupMember[] = [];
+  const pending: { body: MemberRef[]; upTo: number }[] = [{ body, upTo }];
+  const visited = new Set<string>();
+  const wrapped = new Set<MemberRef[]>();
+  while (pending.length > 0) {
+    const step = pending.pop()!;
+    if (scanBackward(d, step.body, step.upTo, out)) {
+      continue; // a required member guarantees a closing wire token
+    }
+    const owner = bodyOwner(d, step.body);
+    if (owner?.kind === 'component' && !visited.has(owner.name)) {
+      visited.add(owner.name);
+      for (const site of componentSites(d, owner.name)) {
+        pending.push({ body: site.parent, upTo: site.index });
+      }
+    } else if (owner?.kind === 'group' && step.upTo < step.body.length && !wrapped.has(step.body)) {
+      // Entry bodies wrap around: the previous ENTRY's tail precedes this position.
+      wrapped.add(step.body);
+      pending.push({ body: step.body, upTo: step.body.length });
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk a body backwards from `upTo`, collecting groups that could be the latest wire
+ * content (looking through optional members and into components). Returns `true` when a
+ * required member seals the context.
+ */
+function scanBackward(
+  d: DictionaryJSON,
+  body: MemberRef[],
+  upTo: number,
+  out: GroupMember[],
+  seen: Set<string> = new Set(),
+): boolean {
+  for (let i = upTo - 1; i >= 0; i--) {
+    const member = body[i]!;
+    if (member.kind === 'field') {
+      if (member.reqd === 'Y') {
+        return true;
+      }
+      continue;
+    }
+    if (member.kind === 'group') {
+      out.push(member);
+      scanBackward(d, member.members, member.members.length, out, seen); // trailing chain inside
+      if (member.reqd === 'Y') {
+        return true;
+      }
+      continue;
+    }
+    if (seen.has(member.name)) {
+      continue; // reference cycle (reported separately) — don't recurse forever
+    }
+    seen.add(member.name);
+    const component = getComponent(d, member.name);
+    if (component && scanBackward(d, component.members, component.members.length, out, seen)) {
+      if (member.reqd === 'Y') {
+        return true;
+      }
+    }
+  }
+  return false;
+}
+
+/** The groups that stay open at the end of a placed member's own wire content. */
+function placedOpenGroups(d: DictionaryJSON, ref: MemberRef): GroupMember[] {
+  const out: GroupMember[] = [];
+  if (ref.kind === 'field') {
+    return out;
+  }
+  if (ref.kind === 'group') {
+    out.push(ref);
+    scanBackward(d, ref.members, ref.members.length, out);
+    return out;
+  }
+  const component = getComponent(d, ref.name);
+  if (component) {
+    scanBackward(d, component.members, component.members.length, out);
+  }
+  return out;
+}
+
+/**
+ * The wire tags that can appear right after position `from` in `body`: subsequent
+ * members' scope-level tags (walking through optional members, which may be absent),
+ * continuing — when the tail cannot guarantee a token — after the owning group/component
+ * in every containing scope, plus the owning group's own delimiter (the next entry).
+ */
+function forwardHazardTags(d: DictionaryJSON, body: MemberRef[], from: number): Set<number> {
+  const out = new Set<number>();
+  const pending: { body: MemberRef[]; from: number }[] = [{ body, from }];
+  const seen = new Set<MemberRef[]>();
+  while (pending.length > 0) {
+    const step = pending.pop()!;
+    if (scanForward(d, step.body, step.from, out)) {
+      continue;
+    }
+    if (seen.has(step.body)) {
+      continue;
+    }
+    seen.add(step.body);
+    const owner = bodyOwner(d, step.body);
+    if (!owner || owner.kind === 'message') {
+      continue;
+    }
+    if (owner.kind === 'group') {
+      const delimiter = firstWireTag(d, owner.member.members, new Set());
+      if (delimiter !== undefined) {
+        out.add(delimiter); // the next entry of the same group opens with it
+      }
+      for (const site of findSites(d, (m) => m === owner.member)) {
+        pending.push({ body: site.parent, from: site.index + 1 });
+      }
+    } else {
+      for (const site of componentSites(d, owner.name)) {
+        pending.push({ body: site.parent, from: site.index + 1 });
+      }
+    }
+  }
+  return out;
+}
+
+/**
+ * Walk a body forward from `from`, collecting scope-level tags until a member guarantees
+ * a wire token for THIS scope (`reqd 'Y'`). Returns `true` when sealed.
+ */
+function scanForward(
+  d: DictionaryJSON,
+  body: MemberRef[],
+  from: number,
+  out: Set<number>,
+  seen: Set<string> = new Set(),
+): boolean {
+  for (let i = from; i < body.length; i++) {
+    const member = body[i]!;
+    if (member.kind === 'field') {
+      out.add(member.tag);
+      if (member.reqd === 'Y') {
+        return true;
+      }
+      continue;
+    }
+    if (member.kind === 'group') {
+      out.add(member.counterTag);
+      if (member.reqd === 'Y') {
+        return true;
+      }
+      continue;
+    }
+    if (seen.has(member.name)) {
+      continue; // reference cycle (reported separately) — don't recurse forever
+    }
+    seen.add(member.name);
+    const component = getComponent(d, member.name);
+    const sealedInside = component ? scanForward(d, component.members, 0, out, seen) : false;
+    if (sealedInside && member.reqd === 'Y') {
+      return true;
+    }
+  }
+  return false;
+}
+
+/** The wire tags a member introduces at its own scope level (not inside nested groups). */
+function introducedTags(ctx: Ctx, ref: MemberRef): number[] {
+  switch (ref.kind) {
+    case 'field':
+      return [ref.tag];
+    case 'group':
+      return [ref.counterTag];
+    case 'component':
+      return [...componentDirectTags(ctx.d, ref.name)];
+  }
+}
+
+// --- body ownership --------------------------------------------------------------------------
+
+type BodyOwner =
+  | { kind: 'message' }
+  | { kind: 'component'; name: string }
+  | { kind: 'group'; member: GroupMember };
+
+/** Which structure a members array belongs to (message, component def, or group body). */
+function bodyOwner(d: DictionaryJSON, body: MemberRef[]): BodyOwner | undefined {
+  for (const message of d.messages) {
+    if (message.members === body) {
+      return { kind: 'message' };
+    }
+  }
+  for (const component of Object.values(d.components)) {
+    if (component.members === body) {
+      return { kind: 'component', name: component.name };
+    }
+  }
+  let found: GroupMember | undefined;
+  const walk = (members: MemberRef[]): boolean => {
+    for (const member of members) {
+      if (member.kind === 'group') {
+        if (member.members === body) {
+          found = member;
+          return true;
+        }
+        if (walk(member.members)) {
+          return true;
+        }
+      }
+    }
+    return false;
+  };
+  for (const message of d.messages) {
+    if (walk(message.members)) {
+      return { kind: 'group', member: found! };
+    }
+  }
+  for (const component of Object.values(d.components)) {
+    if (walk(component.members)) {
+      return { kind: 'group', member: found! };
+    }
+  }
+  return undefined;
+}
+
+/** The component whose definition (transitively) owns a body, if any. */
+function owningComponentName(d: DictionaryJSON, body: MemberRef[]): string | undefined {
+  let current = body;
+  for (;;) {
+    const owner = bodyOwner(d, current);
+    if (!owner || owner.kind === 'message') {
+      return undefined;
+    }
+    if (owner.kind === 'component') {
+      return owner.name;
+    }
+    const sites = findSites(d, (m) => m === owner.member);
+    if (sites.length === 0) {
+      return undefined;
+    }
+    current = sites[0]!.parent; // a group definition occurs at exactly one structural site
+  }
+}
+
+/** One position where a member sits inside a parent members array. */
+interface Site {
+  parent: MemberRef[];
+  index: number;
+}
+
+/** Every site matching `predicate` across messages, component defs, and nested groups. */
+function findSites(d: DictionaryJSON, predicate: (m: MemberRef) => boolean): Site[] {
+  const sites: Site[] = [];
+  const walk = (members: MemberRef[]): void => {
+    members.forEach((member, index) => {
+      if (predicate(member)) {
+        sites.push({ parent: members, index });
+      }
+      if (member.kind === 'group') {
+        walk(member.members);
+      }
+    });
+  };
+  for (const message of d.messages) {
+    walk(message.members);
+  }
+  for (const component of Object.values(d.components)) {
+    walk(component.members);
+  }
+  return sites;
+}
+
+/** Every site referencing a component by name. */
+function componentSites(d: DictionaryJSON, name: string): Site[] {
+  return findSites(d, (m) => m.kind === 'component' && m.name === name);
+}
+
+/** Whether `from`'s expansion (transitively) references component `target`. */
+function componentExpansionContains(d: DictionaryJSON, from: string, target: string): boolean {
+  const seen = new Set<string>();
+  const walk = (members: MemberRef[]): boolean => {
+    for (const member of members) {
+      if (member.kind === 'component') {
+        if (member.name === target) {
+          return true;
+        }
+        if (!seen.has(member.name)) {
+          seen.add(member.name);
+          const component = getComponent(d, member.name);
+          if (component && walk(component.members)) {
+            return true;
+          }
+        }
+      } else if (member.kind === 'group' && walk(member.members)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  const start = getComponent(d, from);
+  return start ? walk(start.members) : false;
+}
+
+// --- delimiter accounting --------------------------------------------------------------------
+
+/**
+ * Snapshot the resolved entry delimiter of every repeating group in the dictionary,
+ * keyed by group object identity (append-only edits never replace group objects). Walks
+ * each container's OWN tree — groups inside component definitions are collected once,
+ * under the component.
+ */
+function collectGroupDelimiters(d: DictionaryJSON): Map<GroupMember, number | undefined> {
+  const out = new Map<GroupMember, number | undefined>();
+  const walk = (members: MemberRef[]): void => {
+    for (const member of members) {
+      if (member.kind === 'group') {
+        out.set(member, firstWireTag(d, member.members, new Set()));
+        walk(member.members);
+      }
+    }
+  };
+  for (const message of d.messages) {
+    walk(message.members);
+  }
+  for (const component of Object.values(d.components)) {
+    walk(component.members);
+  }
+  return out;
+}
+
+/** The first wire tag of a body — the parser's entry delimiter (mirrors Dictionary). */
+function firstWireTag(
+  d: DictionaryJSON,
+  members: MemberRef[],
+  seen: Set<string>,
+): number | undefined {
+  for (const member of members) {
+    switch (member.kind) {
+      case 'field':
+        return member.tag;
+      case 'group':
+        return member.counterTag;
+      case 'component': {
+        if (seen.has(member.name)) {
+          continue;
+        }
+        seen.add(member.name);
+        const component = getComponent(d, member.name);
+        if (!component) {
+          continue;
+        }
+        const tag = firstWireTag(d, component.members, seen);
+        if (tag !== undefined) {
+          return tag;
+        }
+      }
+    }
+  }
+  return undefined;
+}
+
+// --- small shared helpers --------------------------------------------------------------------
+
+function getComponent(d: DictionaryJSON, name: string): ComponentDef | undefined {
+  return hasOwn(d.components, name) ? d.components[name] : undefined;
+}
+
+/** A component's expansion at its own level: field tags and group counter tags. */
+function componentDirectTags(d: DictionaryJSON, name: string): Set<number> {
+  const component = getComponent(d, name);
+  return component ? expandedScope(d, component.members).tags : new Set();
+}
+
+/** How many times a component is referenced across all messages and components. */
+function componentReferenceCount(d: DictionaryJSON, name: string): number {
+  return componentSites(d, name).length;
+}
+
+/** The names of messages whose expansion (transitively) reaches a component. */
+function messagesReaching(d: DictionaryJSON, name: string): string[] {
+  const reaches = (members: MemberRef[], seen: Set<string>): boolean => {
+    for (const member of members) {
+      if (member.kind === 'component') {
+        if (member.name === name) {
+          return true;
+        }
+        if (!seen.has(member.name)) {
+          seen.add(member.name);
+          const component = getComponent(d, member.name);
+          if (component && reaches(component.members, seen)) {
+            return true;
+          }
+        }
+      } else if (member.kind === 'group' && reaches(member.members, seen)) {
+        return true;
+      }
+    }
+    return false;
+  };
+  return d.messages.filter((m) => reaches(m.members, new Set())).map((m) => m.name);
+}
+
+/** Index right before a trailing trailer component (one whose expansion carries tag 10). */
+function beforeTrailerIndex(d: DictionaryJSON, body: MemberRef[]): number {
+  const last = body[body.length - 1];
+  if (last?.kind === 'component' && componentDirectTags(d, last.name).has(10)) {
+    return body.length - 1;
+  }
+  return body.length;
+}
+
+/**
+ * Whether the body already carries the member's identity at its scope level — directly
+ * or through a referenced component. The expanded check matters: a field that is already
+ * reachable via a component in the same body would be emitted twice per scope by encode
+ * and dropped as `parse/duplicate-tag` on re-parse.
+ */
+function hasMemberIdentity(ctx: Ctx, body: MemberRef[], ref: MemberRef): boolean {
+  const scope = expandedScope(ctx.d, body);
+  switch (ref.kind) {
+    case 'field':
+      return scope.tags.has(ref.tag);
+    case 'group':
+      return scope.tags.has(ref.counterTag);
+    case 'component':
+      return scope.components.has(ref.name);
+  }
+}
+
+/**
+ * A body's scope-level expansion: every field tag and group counter tag that puts data
+ * on the wire directly in this scope (descending into components, not into groups), and
+ * every component name referenced (transitively).
+ */
+function expandedScope(
+  d: DictionaryJSON,
+  body: MemberRef[],
+): { tags: Set<number>; components: Set<string> } {
+  const tags = new Set<number>();
+  const components = new Set<string>();
+  const walk = (members: MemberRef[]): void => {
+    for (const member of members) {
+      if (member.kind === 'field') {
+        tags.add(member.tag);
+      } else if (member.kind === 'group') {
+        tags.add(member.counterTag);
+      } else if (!components.has(member.name)) {
+        components.add(member.name);
+        const component = getComponent(d, member.name);
+        if (component) {
+          walk(component.members);
+        }
+      }
+    }
+  };
+  walk(body);
+  return { tags, components };
+}
+
+/** Anchor lookup: a member matching a field, group-counter, or component name. */
+function findMemberIndex(ctx: Ctx, body: MemberRef[], name: string): number {
+  const field = ctx.fieldsByName.get(name);
+  return body.findIndex((member) => {
+    switch (member.kind) {
+      case 'field':
+        return field !== undefined && member.tag === field.tag;
+      case 'group':
+        return field !== undefined && member.counterTag === field.tag;
+      case 'component':
+        return member.name === name;
+    }
+  });
+}
+
+/** Whether a datatype derives from (or is) `ancestor`, walking parents with a cycle guard. */
+function derivesFrom(d: DictionaryJSON, type: string, ancestor: string): boolean {
+  const seen = new Set<string>();
+  let cursor = hasOwn(d.datatypes ?? {}, type) ? d.datatypes[type] : undefined;
+  while (cursor && !seen.has(cursor.name)) {
+    if (cursor.name === ancestor) {
+      return true;
+    }
+    seen.add(cursor.name);
+    cursor =
+      cursor.parent !== undefined && hasOwn(d.datatypes, cursor.parent)
+        ? d.datatypes[cursor.parent]
+        : undefined;
+  }
+  return false;
+}
+
+function describeRef(ctx: Ctx, ref: MemberRef): string {
+  switch (ref.kind) {
+    case 'field':
+      return `Field ${fieldLabel(ctx, ref.tag)}`;
+    case 'group':
+      return `The group headed by ${fieldLabel(ctx, ref.counterTag)}`;
+    case 'component':
+      return `Component "${ref.name}"`;
+  }
+}
+
+function fieldLabel(ctx: Ctx, tag: number | undefined): string {
+  if (tag === undefined) {
+    return '(unresolved)';
+  }
+  const name = ctx.d.fields[tag]?.name;
+  return name ? `${name} (${tag})` : `tag ${tag}`;
+}
+
+function refTag(ref: MemberRef): { refTagID?: number } {
+  switch (ref.kind) {
+    case 'field':
+      return { refTagID: ref.tag };
+    case 'group':
+      return { refTagID: ref.counterTag };
+    case 'component':
+      return {};
+  }
+}
+
+/** Own-property check (see Dictionary.ts — prototype-named keys must miss). */
+function hasOwn(obj: object, key: string): boolean {
+  return Object.prototype.hasOwnProperty.call(obj, key);
+}
+
+/** Non-null, non-array object check that PRESERVES the checked value's type. */
+function isPlainObject<T>(value: T): value is T & object {
+  return typeof value === 'object' && value !== null && !Array.isArray(value);
+}
+
+/** Structural equality over plain dictionary data (field defs, enum lists). */
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) {
+    return true;
+  }
+  if (Array.isArray(a) && Array.isArray(b)) {
+    return a.length === b.length && a.every((item, i) => deepEqual(item, b[i]));
+  }
+  if (isPlainObject(a) && isPlainObject(b)) {
+    const ra = a as Record<string, unknown>;
+    const rb = b as Record<string, unknown>;
+    const ka = Object.keys(ra);
+    return (
+      ka.length === Object.keys(rb).length &&
+      ka.every((k) => hasOwn(rb, k) && deepEqual(ra[k], rb[k]))
+    );
+  }
+  return false;
+}

--- a/packages/fix/src/dictionary/extension.test.ts
+++ b/packages/fix/src/dictionary/extension.test.ts
@@ -1,0 +1,94 @@
+import { describe, expect, expectTypeOf, it } from 'vitest';
+import { extendTags, invertTags } from './extendTags';
+import { type DictionaryExtension, defineExtension, msgTypesOf, tagsOf } from './extension';
+
+// The one-declaration bridge: a single defineExtension declaration drives both the
+// runtime dictionary merge (extendDictionary, tested separately) and the literal typed
+// maps below. Type pins are enforced by `pnpm typecheck`.
+
+const ctrader = defineExtension({
+  id: 'ctrader',
+  fields: {
+    SymbolName: { tag: 1007, type: 'String' },
+    SymbolDigits: { tag: 1008, type: 'int' },
+  },
+  messages: {
+    SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+    CTraderPing: { msgType: 'UP1', members: ['SymbolName'] },
+  },
+});
+
+describe('defineExtension', () => {
+  it('is an identity at runtime', () => {
+    const value = { fields: { A: { tag: 5001, type: 'int' } } } as const;
+    expect(defineExtension(value)).toBe(value);
+  });
+
+  it('pins literals without as const', () => {
+    expectTypeOf(ctrader.fields.SymbolName.tag).toEqualTypeOf<1007>();
+    expectTypeOf(ctrader.messages.CTraderPing.msgType).toEqualTypeOf<'UP1'>();
+    expect(ctrader.fields.SymbolName.tag).toBe(1007);
+  });
+
+  it('rejects a message entry mixing patch and new-message shapes at compile time', () => {
+    // A msgType alongside patch-only keys is neither a NewMessageSpec (members missing)
+    // nor a MessageExtension (msgType is `never` there) — the mistake must not compile.
+    defineExtension({
+      messages: {
+        // @ts-expect-error — msgType plus groups is an invalid mix
+        Broken: { msgType: 'U1', groups: {} },
+      },
+    });
+  });
+
+  it('rejects a pre-declared (widened) extension at compile time', () => {
+    const widened: DictionaryExtension = {
+      fields: { SymbolName: { tag: 1007, type: 'String' } },
+    };
+    // @ts-expect-error — widened tag literals must be a readable error, not a silent
+    // degradation of the derived Tags map to `number`.
+    defineExtension(widened);
+    // An `as const` pre-declaration keeps literals and passes:
+    const fine = { fields: { SymbolName: { tag: 1007, type: 'String' } } } as const;
+    const pinned = defineExtension(fine);
+    expectTypeOf(pinned.fields.SymbolName.tag).toEqualTypeOf<1007>();
+  });
+});
+
+describe('tagsOf', () => {
+  it('derives the literal name → tag map from the declaration', () => {
+    const tags = tagsOf(ctrader);
+    expect(tags).toEqual({ SymbolName: 1007, SymbolDigits: 1008 });
+    expectTypeOf(tags.SymbolName).toEqualTypeOf<1007>();
+    expectTypeOf(tags.SymbolDigits).toEqualTypeOf<1008>();
+  });
+
+  it('returns an empty map for a fieldless extension', () => {
+    expect(tagsOf(defineExtension({ messages: {} }))).toEqual({});
+  });
+
+  it('feeds extendTags/invertTags with full literal typing (the two layers connect)', () => {
+    const BaseTags = { Symbol: 55 } as const;
+    const Tags = extendTags(BaseTags, tagsOf(ctrader));
+    const TagNames = invertTags(Tags);
+    expectTypeOf(Tags.SymbolName).toEqualTypeOf<1007>();
+    expectTypeOf(TagNames[1007]).toEqualTypeOf<'SymbolName'>();
+    expect(Tags.SymbolName).toBe(1007);
+    expect(TagNames[1007]).toBe('SymbolName');
+  });
+});
+
+describe('msgTypesOf', () => {
+  it('derives new messages and skips patches', () => {
+    const msgTypes = msgTypesOf(ctrader);
+    expect(msgTypes).toEqual({ CTraderPing: 'UP1' });
+    expectTypeOf(msgTypes.CTraderPing).toEqualTypeOf<'UP1'>();
+    // The SecurityList patch (no msgType) must not appear, at type or value level:
+    expect('SecurityList' in msgTypes).toBe(false);
+    expectTypeOf<keyof typeof msgTypes>().toEqualTypeOf<'CTraderPing'>();
+  });
+
+  it('returns an empty map for an extension without new messages', () => {
+    expect(msgTypesOf(defineExtension({ fields: {} }))).toEqual({});
+  });
+});

--- a/packages/fix/src/dictionary/extension.ts
+++ b/packages/fix/src/dictionary/extension.ts
@@ -1,0 +1,240 @@
+/**
+ * The dictionary extension schema: ONE declaration describing venue-specific additions
+ * (fields, enum values, components, messages, and placements into existing structures)
+ * that drives BOTH layers of dictionary extensibility:
+ *
+ * - the runtime merge — {@link ./extendDictionary.extendDictionary} applies the
+ *   declaration to a {@link ./types.DictionaryJSON} and reports `extend/*` issues;
+ * - the typing bridge — {@link tagsOf}/{@link msgTypesOf} derive literal `name → tag` /
+ *   `name → msgType` maps from the same declaration, ready for
+ *   {@link ./extendTags.extendTags}/{@link ./extendTags.invertTags}.
+ *
+ * Everything is keyed by NAME (tags live in values): the record shape makes the
+ * key/tag-mismatch and duplicate-name-in-extension authoring errors unrepresentable,
+ * and is exactly what the literal-type derivation needs.
+ *
+ * Wrap the declaration in {@link defineExtension} — a zero-cost identity whose TS 5
+ * `const` type parameter pins every literal (no `as const` needed) and whose
+ * {@link GuardWidening} constraint turns an accidentally widened declaration into a
+ * readable compile error instead of silently degrading the derived types.
+ */
+import type { MessageCategory, Reqd } from './types';
+
+/** One allowed value to add to a field's enum. `description` defaults to `name`. */
+export interface ExtensionEnumValue {
+  /** The on-the-wire value, verbatim and opaque (`"1"`, `"004"`, `"AB"`). */
+  readonly value: string;
+  /** A code-identifier-safe name, e.g. `"Buy"`. The identity on conflicts. */
+  readonly name: string;
+  /** Human description; defaults to {@link name} when omitted. */
+  readonly description?: string;
+}
+
+/**
+ * A new field. Keyed by its NAME in {@link DictionaryExtension.fields}; the tag lives
+ * here. `isGroupCounter` is never authored — it is inferred from {@link type} deriving
+ * from `NumInGroup`, mirroring the invariant documented on the dictionary contract.
+ */
+export interface ExtensionFieldDef {
+  /** The field's numeric tag, e.g. `1007`. */
+  readonly tag: number;
+  /** Must name an existing datatype in the target dictionary (`'String'`, `'int'`, `'Price'`, …). */
+  readonly type: string;
+  /** Allowed values, when the new field is enumerated. */
+  readonly enumValues?: readonly ExtensionEnumValue[];
+  /** For a `data`-based field: the tag of the companion `Length` field preceding it. */
+  readonly lengthField?: number;
+  /** Human description, carried into the merged {@link FieldDef}. */
+  readonly description?: string;
+}
+
+/**
+ * A member to place into a body. The string shorthand is an optional field by name
+ * (`reqd: 'N'`). Names resolve against the extension's own {@link DictionaryExtension.fields}
+ * first, then the base dictionary's fields/components.
+ */
+export type MemberSpec =
+  | string
+  | { readonly field: string; readonly reqd?: Reqd }
+  | { readonly component: string; readonly reqd?: Reqd }
+  | {
+      /** A NEW nested repeating group; `group` names its counter field. */
+      readonly group: string;
+      readonly reqd?: Reqd;
+      readonly members: readonly MemberSpec[];
+    };
+
+/** Members to add to one repeating group's entry body. */
+export interface GroupExtension {
+  readonly append: readonly MemberSpec[];
+  /**
+   * Anchor member (field/component/group-counter name) to insert immediately AFTER;
+   * omit to append at the end of the entry body (which is also the encode position).
+   * `before`/`start` are deliberately unsupported: a group's first body field is its
+   * entry delimiter, and inserting ahead of it would change entry detection.
+   */
+  readonly after?: string;
+}
+
+/** A patch to an existing message (addressed by name via the record key). */
+export interface MessageExtension {
+  /** Never set on a patch — its presence is what marks an entry as a {@link NewMessageSpec}. */
+  readonly msgType?: never;
+  /** Appended at the end of the body, kept BEFORE the trailing Standard Message Trailer. */
+  readonly append?: readonly MemberSpec[];
+  /** Anchor for {@link append}, as in {@link GroupExtension.after}. */
+  readonly after?: string;
+  /**
+   * Additions to EXISTING repeating groups, keyed by counter-field-name path — dotted
+   * for nesting (`'NoRelatedSym.NoUnderlyings'`). A group that lives behind a shared
+   * component is auto-resolved only when it is reachable via exactly one
+   * single-reference component chain; otherwise the placement is refused with a
+   * `extend/target-not-found` hint naming the component to target explicitly.
+   */
+  readonly groups?: Readonly<Record<string, GroupExtension>>;
+}
+
+/** A brand-new message (the presence of `msgType` is what marks an entry as new). */
+export interface NewMessageSpec {
+  /** The `MsgType` (tag 35) value, case-sensitive (`'U1'`, `'UP1'`, …). */
+  readonly msgType: string;
+  /** Session (`admin`) vs application (`app`) message. Defaults to `'app'`. */
+  readonly category?: MessageCategory;
+  /**
+   * Body only — the base dictionary's Standard Message Header/Trailer component refs
+   * are injected automatically (reported via `extend/header-trailer-injected`).
+   */
+  readonly members: readonly MemberSpec[];
+}
+
+/**
+ * A component entry: `{ members }` defines a NEW component; the other form extends an
+ * existing one (additions become visible in every referencing scope — deliberate, and
+ * reported via `extend/component-fanout`).
+ */
+export type ComponentExtension =
+  | { readonly members: readonly MemberSpec[] }
+  | {
+      readonly append?: readonly MemberSpec[];
+      readonly after?: string;
+      readonly groups?: Readonly<Record<string, GroupExtension>>;
+    };
+
+/** One venue extension declaration — the single source of truth for both layers. */
+export interface DictionaryExtension {
+  /** Provenance label, e.g. `'ctrader'`; echoed into issue paths and the merged JSON. */
+  readonly id?: string;
+  /** New fields, keyed by NAME. */
+  readonly fields?: Readonly<Record<string, ExtensionFieldDef>>;
+  /** Enum values appended to EXISTING fields, keyed by field NAME. */
+  readonly enums?: Readonly<Record<string, readonly ExtensionEnumValue[]>>;
+  /** New components and additions to existing ones, keyed by component name. */
+  readonly components?: Readonly<Record<string, ComponentExtension>>;
+  /** New messages and patches to existing ones, keyed by message name. */
+  readonly messages?: Readonly<Record<string, MessageExtension | NewMessageSpec>>;
+}
+
+// --- literal-type derivation (zero runtime cost) -----------------------------------------
+
+type FieldsOf<E extends DictionaryExtension> = E['fields'] & {};
+type MsgsOf<E extends DictionaryExtension> = E['messages'] & {};
+
+/**
+ * The literal `name → tag` map type derived from an extension's `fields` record —
+ * `TagsOf<typeof ctrader>` is `{ readonly SymbolName: 1007; readonly SymbolDigits: 1008 }`.
+ * Feed the value-level counterpart {@link tagsOf} to `extendTags`.
+ */
+export type TagsOf<E extends DictionaryExtension> = Readonly<{
+  [K in keyof FieldsOf<E> & string]: FieldsOf<E>[K] extends { tag: infer T extends number }
+    ? T
+    : never;
+}>;
+
+/**
+ * The literal `name → msgType` map type derived from an extension's NEW messages
+ * (entries carrying `msgType`); message patches are excluded.
+ */
+export type MsgTypesOf<E extends DictionaryExtension> = Readonly<{
+  [K in keyof MsgsOf<E> & string as MsgsOf<E>[K] extends { msgType: string }
+    ? K
+    : never]: MsgsOf<E>[K] extends { msgType: infer M extends string } ? M : never;
+}>;
+
+/**
+ * The compile error surfaced by {@link GuardWidening} when an extension's literals were
+ * widened before reaching {@link defineExtension}. Not meant to be used directly.
+ */
+export interface WidenedExtensionError {
+  readonly 'ERROR: extension literals were widened': 'declare the extension inline at the defineExtension call site (or as const) so tags stay literal types like 1007';
+}
+
+/**
+ * Compile-time guard: resolves to `unknown` (no-op) when the extension's tag and
+ * msgType literals survived inference, and to {@link WidenedExtensionError} when they
+ * widened to `number`/`string` — which happens when the declaration was pre-typed as
+ * {@link DictionaryExtension} before the call. Without this, the flagship literal
+ * hovers would silently degrade; with it, the degradation is a readable type error.
+ */
+export type GuardWidening<E extends DictionaryExtension> = (TagsOf<E>[keyof TagsOf<E>] extends never
+  ? unknown
+  : number extends TagsOf<E>[keyof TagsOf<E>]
+    ? WidenedExtensionError
+    : unknown) &
+  (MsgTypesOf<E>[keyof MsgTypesOf<E>] extends never
+    ? unknown
+    : string extends MsgTypesOf<E>[keyof MsgTypesOf<E>]
+      ? WidenedExtensionError
+      : unknown);
+
+/**
+ * Pin an extension declaration's literal types once — a zero-cost identity whose TS 5
+ * `const` type parameter keeps every `tag: 1007` / `msgType: 'UP1'` literal without
+ * `as const`, so the SAME value can drive `extendDictionary` (runtime) and
+ * {@link tagsOf}/{@link msgTypesOf} (types).
+ *
+ * ```ts
+ * const ctrader = defineExtension({
+ *   id: 'ctrader',
+ *   fields: {
+ *     SymbolName:   { tag: 1007, type: 'String' },
+ *     SymbolDigits: { tag: 1008, type: 'int' },
+ *   },
+ *   messages: {
+ *     SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+ *   },
+ * });
+ * ```
+ */
+export function defineExtension<const E extends DictionaryExtension>(ext: E & GuardWidening<E>): E {
+  return ext;
+}
+
+/**
+ * Derive the literal `name → tag` map from an extension declaration, typed as
+ * {@link TagsOf}. Pure and total; collisions are the runtime merge's concern.
+ *
+ * ```ts
+ * export const Tags = extendTags(Fix44Tags, tagsOf(ctrader)); // Tags.SymbolName: 1007
+ * ```
+ */
+export function tagsOf<const E extends DictionaryExtension>(ext: E): TagsOf<E> {
+  const out: Record<string, number> = {};
+  for (const [name, def] of Object.entries(ext.fields ?? {})) {
+    out[name] = def.tag;
+  }
+  return out as TagsOf<E>;
+}
+
+/**
+ * Derive the literal `name → msgType` map of an extension's NEW messages, typed as
+ * {@link MsgTypesOf}. Message patches (entries without `msgType`) are skipped.
+ */
+export function msgTypesOf<const E extends DictionaryExtension>(ext: E): MsgTypesOf<E> {
+  const out: Record<string, string> = {};
+  for (const [name, spec] of Object.entries(ext.messages ?? {})) {
+    if (typeof spec.msgType === 'string') {
+      out[name] = spec.msgType;
+    }
+  }
+  return out as MsgTypesOf<E>;
+}

--- a/packages/fix/src/dictionary/types.ts
+++ b/packages/fix/src/dictionary/types.ts
@@ -186,4 +186,10 @@ export interface DictionaryJSON {
   messages: MessageDef[];
   /** Known limitations of this generated dictionary. */
   coverageGaps?: CoverageGap[];
+  /**
+   * Provenance of applied extensions: the `id` of every extension declaration merged
+   * into this dictionary by `extendDictionary`, in application order. Absent on
+   * pristine generated dictionaries.
+   */
+  extensions?: string[];
 }

--- a/packages/fix/src/errors.ts
+++ b/packages/fix/src/errors.ts
@@ -11,7 +11,11 @@ export type FixSeverity = 'error' | 'warning' | 'info';
  * and exhaustiveness — while {@link FixIssue.code} stays open (`KnownIssueCode | string`)
  * so a custom dictionary or future milestone can introduce new codes without a type break.
  * The `dict/*` family is raised by `validateDictionary`, the `parse/*` family by `parse`,
- * and the `validate/*` family (presence/enum/datatype/conditional) by `validate`.
+ * the `validate/*` family (presence/enum/datatype/conditional) by `validate`, and the
+ * `extend/*` family by `extendDictionary`. For `extend/*` codes the severity encodes the
+ * outcome: `error` = the operation was skipped or reverted, `warning` = applied — or, for
+ * `extend/duplicate-member`, already satisfied (the redundant member was not added again)
+ * — but worth review, `info` = advisory.
  */
 export type KnownIssueCode =
   // --- dictionary integrity (validateDictionary) ---
@@ -84,7 +88,96 @@ export type KnownIssueCode =
   // A field that a conditional rule makes required given the message's state is absent
   // (e.g. the `Length` companion of a present `data` field, or `OrigSendingTime` when
   // `PossDupFlag` = `Y`).
-  | 'validate/conditional-required';
+  | 'validate/conditional-required'
+  // --- dictionary extension (extendDictionary) ---
+  // fields
+  // An extension field's tag already exists; the extension definition replaces it.
+  // Suppressed when the redefinition is identical (idempotent re-application).
+  | 'extend/field-tag-collision'
+  // An extension field's name is already bound to a DIFFERENT tag; the field is skipped
+  // (applying it would make the merged dictionary fail `dict/duplicate-field-name`).
+  | 'extend/field-name-collision'
+  // An extension field's tag is not a positive integer; the field is skipped.
+  | 'extend/field-bad-tag'
+  // An extension field's `type` names no datatype in the dictionary; the field is skipped.
+  | 'extend/field-unknown-type'
+  // A new field's tag lies outside the FIX user-defined ranges (5000-9999, 20000+).
+  // Advisory only — venues do this in practice (e.g. cTrader's 1007/1008).
+  | 'extend/tag-outside-user-range'
+  // A new `data`-based field has no `lengthField`, so a value embedding the separator
+  // cannot be scanned safely. Applied, but flagged.
+  | 'extend/data-length-unwired'
+  // enums
+  // An `enums` entry names a field absent from the merged dictionary; the entry is skipped.
+  | 'extend/enum-unknown-field'
+  // An added enum value re-declares an existing wire value under a different name; the
+  // extension entry replaces the base one. Identical value+name pairs dedupe silently.
+  | 'extend/enum-value-conflict'
+  // components & messages
+  // A new component's name already exists; the definition is skipped (extend the existing
+  // component with the append form instead).
+  | 'extend/component-collision'
+  // A component definition or placement would create a component reference cycle (which
+  // the runtime cannot expand); the definition is deleted or the member reverted.
+  | 'extend/component-cycle'
+  // A new message re-uses an existing `MsgType`; the extension message REPLACES the base
+  // message in place (an appended duplicate would be unreachable behind first-wins lookup).
+  | 'extend/msgtype-collision'
+  // A new message's name duplicates another message's name on a different `MsgType`
+  // (mirrors the warning-level `dict/duplicate-message-name`). Applied.
+  | 'extend/message-name-collision'
+  // The base dictionary's Standard Message Header/Trailer refs were injected into a new
+  // message that did not list them.
+  | 'extend/header-trailer-injected'
+  // No header/trailer component could be detected in the base dictionary; the new message
+  // is applied without them (encode would silently drop session fields — review).
+  | 'extend/header-trailer-missing'
+  // placements
+  // A placement target could not be resolved: unknown message/component name, ambiguous
+  // message name, or a group path not reachable — including a group that lives behind a
+  // shared component (the message carries a "reachable via component 'X'" hint).
+  | 'extend/target-not-found'
+  // A placed MemberSpec references a field/component name defined neither in the base
+  // dictionary nor in the extension; the whole placement is skipped.
+  | 'extend/unknown-member'
+  // An `after` anchor matches no member of the resolved target body; the placement is skipped.
+  | 'extend/member-not-found'
+  // A placed member's identity (field tag / component name / group counter) already exists
+  // in the target body; that member is skipped. This is the idempotency/overlap guard that
+  // keeps re-applied or overlapping extensions from double-emitting tags on the wire.
+  | 'extend/duplicate-member'
+  // A new group's counter field's datatype does not derive from `NumInGroup` (mirrors
+  // `dict/non-counter-group-head`). Applied — fix the field's type.
+  | 'extend/counter-not-marked'
+  // Post-condition check: the placement would change some group's resolved entry delimiter
+  // (its first wire tag), breaking entry detection; the placement is reverted.
+  | 'extend/group-delimiter-shift'
+  // A placed member's tag also belongs to the scope (or is the delimiter) of a repeating
+  // group that could be open on the wire right at the insertion point — either a group
+  // before it (looking through optional members, which may be absent at runtime) or, for a
+  // placed group, members that follow it. On re-parse the value would land in the wrong
+  // entry. The member is skipped; anchor it with `after` elsewhere, or place it inside the
+  // conflicting group instead.
+  | 'extend/ambiguous-boundary'
+  // A NEW repeating group's body resolves to no leading wire field, so the parser would
+  // have no entry delimiter; the placement is skipped.
+  | 'extend/unresolvable-group-delimiter'
+  // A placed `data` field's Length companion (its FieldDef.lengthField) is not a member
+  // positioned before it in the same body — encode would drop the caller-supplied length
+  // and an SOH-embedding value would corrupt the frame. Applied; place the length field.
+  | 'extend/data-length-not-placed'
+  // A NumInGroup-derived field was placed as a plain scalar member; on the wire it heads
+  // a repeating group, so real traffic would mis-parse. Applied — use the {group, members}
+  // member form instead.
+  | 'extend/counter-as-field'
+  // An extension entry is structurally malformed (not an object, a message spec without a
+  // members array, a non-array enum list, …); the entry is skipped.
+  | 'extend/invalid-spec'
+  // A placement gave a previously delimiter-less group body its first resolvable wire tag.
+  | 'extend/delimiter-defined'
+  // A placement touched a shared component; reports every message the addition now
+  // reaches. Advisory — component reuse is the FIX model, but the fan-out should be known.
+  | 'extend/component-fanout';
 
 /**
  * A single diagnostic, returned as data — never thrown — by every analysis entry point

--- a/packages/fix/src/index.ts
+++ b/packages/fix/src/index.ts
@@ -69,5 +69,24 @@ export type {
   InvertMsgTypes,
 } from './dictionary/extendTags';
 
+// Dictionary extension (runtime merge + one-declaration bridge).
+export { extendDictionary } from './dictionary/extendDictionary';
+export type { ExtendResult } from './dictionary/extendDictionary';
+export { defineExtension, tagsOf, msgTypesOf } from './dictionary/extension';
+export type {
+  DictionaryExtension,
+  ExtensionFieldDef,
+  ExtensionEnumValue,
+  MemberSpec,
+  GroupExtension,
+  MessageExtension,
+  NewMessageSpec,
+  ComponentExtension,
+  TagsOf,
+  MsgTypesOf,
+  GuardWidening,
+  WidenedExtensionError,
+} from './dictionary/extension';
+
 // Diagnostics.
 export type { FixIssue, FixSeverity, KnownIssueCode } from './errors';


### PR DESCRIPTION
## What

The runtime layer of dictionary extensibility (stacked on #20): `extendDictionary(base, ...extensions)` merges one or more `DictionaryExtension` declarations into a **fresh** `DictionaryJSON` the engine consumes unchanged, plus the one-declaration bridge (`defineExtension`, `tagsOf`, `msgTypesOf`) that derives the typed maps from the same declaration.

One declaration covers the whole surface — keyed by name everywhere, so key/tag mismatches are unrepresentable:

- **fields** (datatype-checked; `isGroupCounter` inferred from `NumInGroup`, never authored)
- **enums** — values appended to existing fields (identical pairs dedupe silently; conflicts warn, extension wins)
- **components** — new definitions and appends to existing ones (fan-out reported)
- **messages** — new messages (standard header/trailer auto-injected) and patches: `append` with optional `after` anchor, `groups` with dotted counter-name paths (`'NoRelatedSym.NoUnderlyings'`), auto-descending through single-reference components (the cTrader `SecListGrp` shape)

## Safety pipeline

Placements are append/after-anchor only, and every operation runs through: an expanded-scope duplicate guard (including all scopes referencing a patched component), **bidirectional** boundary checks that treat optional members as potentially absent — a placed member must not re-parse into a group that could be open before it, nor capture followers into a group it opens — component-cycle detection, new-group delimiter resolvability, data-field Length adjacency, and a dictionary-wide delimiter post-check that **reverts** any placement that would shift a group's entry delimiter.

Contract (all tested): never throws on data problems; pure (deep clone, inputs untouched); idempotent; composes left-to-right; **validity-preserving** — a gate-clean base plus error-free issues yields a gate-clean result. 27 new stable `extend/*` issue codes; severity encodes the outcome (error = skipped/reverted, warning = applied, info = advisory).

## The motivating case, end-to-end

`packages/fix-dict-fix44/src/extend.test.ts` pins the cTrader scenario: the stock dictionary provably mis-nests a multi-instrument SecurityList carrying `SymbolName(1007)`/`SymbolDigits(1008)` inside `NoRelatedSym` (`parse/group-count-mismatch`); the extended dictionary parses all entries with zero issues, round-trips **byte-identically** through encode, keeps the group delimiter at `Symbol(55)`, and validates clean — while `extendTags(Tags, tagsOf(ctrader))` hovers `Tags.SymbolName` as literal `1007`.

## Review hardening

A 20-agent adversarial review (3 lenses, every finding execution-verified) ran against the initial implementation; all 12 distinct confirmed findings are fixed with regression tests: component cycles, boundary-check bypass via component targets, one-directional boundary checking, optional-member adjacency gaps, delimiter-less new groups, provenance idempotency, malformed-spec crashes, and more.

## Notes

- `DictionaryJSON` gains optional `extensions?: string[]` (applied extension ids, deduped).
- `structuredClone` is the deep-clone primitive (global in Node ≥ 18 and browsers; bundle-clean).
- Gate: typecheck ✓ · 345 tests ✓ · lint ✓ · build ✓ · check:bundle ✓ · dist smoke-tested (CJS **and** ESM, including the cTrader flow and cycle guard).
- Changeset: minor for `@boarteam/fix`, all 27 codes called out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)