### PR TITLE
docs: extending dictionaries with venue-custom tags

### DIFF
--- a/README.md
+++ b/README.md
@@ -216,9 +216,67 @@ const { message, issues } = fix.parse(pipeDelimitedLine, { soh: '|' });
 
 `parse` options: `soh` (default the SOH byte `0x01`; pass `"|"` to read pipe-delimited logs) and `checkFraming` (default `true`; framing findings come back as issues, never a rejection).
 
+### Extending the dictionary (venue-custom tags)
+
+Real venues extend FIX beyond the spec — cTrader, for example, sends `SymbolName(1007)` and
+`SymbolDigits(1008)` _inside_ the `NoRelatedSym` repeating group of SecurityList (35=y).
+Unknown tags inside a group break group reconstruction, and `encode` only emits fields the
+dictionary places. `extendDictionary` fixes both from one declaration:
+
+```ts
+import { defineExtension, extendDictionary, createFixEngine } from '@boarteam/fix';
+import { dictionary as fix44 } from '@boarteam/fix-dict-fix44';
+
+const ctrader = defineExtension({
+  id: 'ctrader',
+  fields: {
+    SymbolName: { tag: 1007, type: 'String' },
+    SymbolDigits: { tag: 1008, type: 'int' },
+  },
+  messages: {
+    SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+  },
+});
+
+const { dictionary, issues } = extendDictionary(fix44, ctrader); // never throws — issues are data
+const fix = createFixEngine(dictionary);
+// SecurityList now parses with 1007/1008 nested per instrument, and encode round-trips them.
+```
+
+An extension can add **fields**, **enum values** on existing fields, **components**, whole
+**messages** (the standard header/trailer are injected for you), and place members into message
+bodies or repeating groups — `after: 'Instrument'` anchors a wire position, dotted paths
+(`'NoRelatedSym.NoUnderlyings'`) reach nested groups. Placements are append-only by design: a
+group's first field is its entry delimiter, and `extendDictionary` reverts any operation that
+would shift one (`extend/group-delimiter-shift`), skips duplicates, and rejects placements that
+could re-parse into the wrong group (`extend/ambiguous-boundary`). Everything it does or refuses
+to do is reported through stable `extend/*` issue codes — `error` means skipped or reverted, so
+if the base passed `validateDictionary` and the result has no error-severity issues, the result
+passes too.
+
+The **same declaration** drives the typed maps — no duplication, full literal typing (TS ≥ 5.0):
+
+```ts
+import { extendTags, invertTags, tagsOf } from '@boarteam/fix';
+import { Tags as Fix44Tags } from '@boarteam/fix-dict-fix44';
+
+export const Tags = extendTags(Fix44Tags, tagsOf(ctrader)); // Tags.SymbolName hovers as 1007
+export type TagName = keyof typeof Tags; // includes 'SymbolName'
+export const TagNames = invertTags(Tags); // TagNames[1007] hovers as 'SymbolName'
+```
+
+For a reusable dialect, put the declaration and the derived exports in one module mirroring a
+dict package's surface (`dictionary`, `Tags`, `TagNames`, `MsgType`, `MsgTypeNames`) — see the
+runnable [`examples/extend-dictionary.mjs`](examples/extend-dictionary.mjs). Two things keep such
+a module honest: fail fast on error-severity issues at module init, and — if the module ships as
+a package that emits `.d.ts` — annotate the exports with the provided alias types (`ExtendTags`,
+`InvertTags`, `ExtendMsgTypes`, `InvertMsgTypes`) so the declaration emit stays small and nominal
+instead of structurally inlining the 900-key base map. The same pattern scales to publishable
+venue packages (e.g. a future `@boarteam/fix-dict-fix44-ctrader`).
+
 ### Lower-level building blocks
 
-If you do not want the engine wrapper, the same capabilities are exported as free functions: `parse`, `parseAll`, `encode`, `validate`, `tokenize`, `splitMessages`, `decodeValue`, `calculateChecksum`, `bodyLength`, `loadDictionary`, `Dictionary`, and `validateDictionary`.
+If you do not want the engine wrapper, the same capabilities are exported as free functions: `parse`, `parseAll`, `encode`, `validate`, `tokenize`, `splitMessages`, `decodeValue`, `calculateChecksum`, `bodyLength`, `loadDictionary`, `Dictionary`, `validateDictionary`, and the dictionary-extension helpers (`extendDictionary`, `defineExtension`, `tagsOf`, `msgTypesOf`, `extendTags`, `invertTags`, `extendMsgTypes`, `invertMsgTypes`).
 
 ### Output shapes
 

--- a/examples/examples.test.ts
+++ b/examples/examples.test.ts
@@ -7,8 +7,19 @@ import { dictionary } from '@boarteam/fix-dict-fix44';
 import { run as runParseAndValidate } from './parse-and-validate.mjs';
 import { run as runEncode } from './encode-a-message.mjs';
 import { run as runDemo } from './demo-decode.mjs';
+import { run as runExtend } from './extend-dictionary.mjs';
 
 describe('examples', () => {
+  it('extend-dictionary nests the cTrader custom tags and keeps every gate clean', () => {
+    const r = runExtend();
+    expect(r.extendErrors).toBe(0);
+    expect(r.gateIssues).toBe(0);
+    expect(r.instruments).toBe(3);
+    expect(r.parseIssues).toBe(0);
+    expect(r.symbolNameTag).toBe(1007);
+    expect(r.reverseName).toBe('SymbolName');
+  });
+
   it('parse-and-validate decodes the repeating group', () => {
     const result = runParseAndValidate();
     expect(result.msgType).toBe('W');

--- a/examples/extend-dictionary.mjs
+++ b/examples/extend-dictionary.mjs
@@ -1,0 +1,96 @@
+// Extend the FIX 4.4 dictionary with venue-custom tags — the cTrader SecurityList case.
+//
+//   pnpm --filter @boarteam/fix-examples start:extend
+//
+// cTrader transmits SymbolName(1007)/SymbolDigits(1008) INSIDE the NoRelatedSym
+// repeating group of SecurityList (35=y). The stock dictionary doesn't know them there,
+// so the group walker closes the group after the first instrument and mis-nests the
+// rest. One extension declaration fixes parsing, encoding, AND the typed tag maps.
+import {
+  createFixEngine,
+  defineExtension,
+  extendDictionary,
+  extendTags,
+  invertTags,
+  tagsOf,
+  validateDictionary,
+} from '@boarteam/fix';
+import { Tags as Fix44Tags, dictionary as fix44 } from '@boarteam/fix-dict-fix44';
+
+// ONE declaration drives both layers (runtime merge + literal typing):
+const ctrader = defineExtension({
+  id: 'ctrader',
+  fields: {
+    SymbolName: { tag: 1007, type: 'String' },
+    SymbolDigits: { tag: 1008, type: 'int' },
+  },
+  messages: {
+    SecurityList: { groups: { NoRelatedSym: { append: ['SymbolName', 'SymbolDigits'] } } },
+  },
+});
+
+// A 3-instrument SecurityList as cTrader sends it (pipe-delimited log capture).
+const raw = [
+  '8=FIX.4.4',
+  '9=0',
+  '35=y',
+  '49=cServer',
+  '56=client',
+  '34=2',
+  '52=20240101-12:00:00.000',
+  '320=req-1',
+  '322=resp-1',
+  '560=0',
+  '146=3',
+  '55=1',
+  '1007=EURUSD',
+  '1008=5',
+  '55=2',
+  '1007=GBPUSD',
+  '1008=5',
+  '55=3',
+  '1007=USDJPY',
+  '1008=3',
+  '10=000',
+  '',
+].join('|');
+
+/** Run the example and return a small result object (used by the test harness). */
+export function run() {
+  // Layer 1 — runtime: a NEW dictionary; the base is never mutated. Issues are data.
+  const { dictionary, issues } = extendDictionary(fix44, ctrader);
+  console.log(`extend issues: ${issues.map((i) => `${i.severity}:${i.code}`).join(', ')}`);
+  // -> two info notes that 1007/1008 sit outside the user-defined tag ranges (cTrader
+  //    proves venues do this), and one info note that the placement went through the
+  //    SecListGrp component. No errors, no warnings.
+  const gate = validateDictionary(dictionary); // the same gate as any dictionary
+  console.log(`validateDictionary: ${gate.length} issues`);
+
+  const fix = createFixEngine(dictionary);
+  const { message, issues: parseIssues } = fix.parse(raw, { soh: '|', checkFraming: false });
+  const entries = message.groups?.[146] ?? [];
+  console.log(`${entries.length} instruments:`);
+  for (const entry of entries) {
+    console.log(`  ${entry.fields?.[1007]?.raw} digits=${entry.fields?.[1008]?.value}`);
+  }
+
+  // Layer 2 — typing, driven by the SAME declaration. Tags.SymbolName hovers as 1007;
+  // TagNames[1007] hovers as 'SymbolName'.
+  const Tags = extendTags(Fix44Tags, tagsOf(ctrader));
+  const TagNames = invertTags(Tags);
+  console.log(`Tags.SymbolName=${Tags.SymbolName}, TagNames[1007]=${TagNames[1007]}`);
+
+  return {
+    extendIssues: issues.length,
+    extendErrors: issues.filter((i) => i.severity === 'error').length,
+    gateIssues: gate.length,
+    instruments: entries.length,
+    parseIssues: parseIssues.length,
+    symbolNameTag: Tags.SymbolName,
+    reverseName: TagNames[1007],
+  };
+}
+
+if (import.meta.url === `file://${process.argv[1]}`) {
+  run();
+}

--- a/examples/package.json
+++ b/examples/package.json
@@ -8,7 +8,8 @@
   "scripts": {
     "start:parse": "node parse-and-validate.mjs",
     "start:encode": "node encode-a-message.mjs",
-    "start:demo": "node demo-decode.mjs"
+    "start:demo": "node demo-decode.mjs",
+    "start:extend": "node extend-dictionary.mjs"
   },
   "dependencies": {
     "@boarteam/fix": "workspace:*",


### PR DESCRIPTION
## What

Documentation and a runnable example for the dictionary-extensibility feature (stacked on #21, which stacks on #20).

- **README — "Extending the dictionary (venue-custom tags)"**: the cTrader motivating case, what an extension can add, the append-only placement semantics and safety guarantees (`extend/group-delimiter-shift` revert, `extend/ambiguous-boundary`), the `extend/*` severity contract, the one-declaration typed-maps flow, and the venue-module recipe — fail fast on error-severity issues, annotate exports with the alias types when emitting `.d.ts` (keeps declaration emit nominal instead of inlining the 900-key base map), and the future publishable venue-package pattern (`@boarteam/fix-dict-fix44-ctrader`).
- **`examples/extend-dictionary.mjs`** — the full cTrader flow (extend → gate → parse a 3-instrument SecurityList → typed maps), wired into the CI-tested examples harness (`start:extend` script + assertions in `examples.test.ts`), so the README's claims stay green.
- Typedoc covers the new API through the existing `packages/fix` entry point; no new warnings (the new sources resolve all their `@link`s).

## Gate

typecheck ✓ · 346 tests ✓ (incl. the new example assertions) · lint ✓ · typedoc 0 errors, warnings unchanged from main.

No changeset: docs and a private examples package only — no published-package changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)