### PR TITLE
ci(release): use Node 24 and run only on changeset changes

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,11 +3,17 @@ name: Release
 # When commits land on main:
 #   - if there are pending changesets, open/refresh a "Version Packages" PR;
 #   - once that PR is merged (no changesets left), build and publish to npm.
-# Requires an NPM_TOKEN repository secret (an npm automation/granular token with publish
-# rights to the @boarteam scope — automation tokens bypass 2FA, so no OTP is needed).
+# Auth is npm OIDC trusted publishing (no NPM_TOKEN secret needed).
+#
+# The paths filter keeps this job off docs/CI-only merges: adding a changeset touches
+# .changeset/, and merging the Version Packages PR deletes the consumed changesets (also
+# under .changeset/), so both the version and publish phases still trigger.
 on:
   push:
     branches: [main]
+    paths: ['.changeset/**']
+  # Manual re-run, e.g. after a transient failure, without waiting for the next changeset.
+  workflow_dispatch: {}
 
 concurrency: release
 
@@ -26,16 +32,15 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
 
-      - name: Use Node 20
+      # Node 24 ships npm >= 11.5.1, which OIDC trusted publishing requires. (Node 20's
+      # npm 10 is too old, and upgrading via `npm install -g npm@latest` broke when npm 12
+      # dropped Node 20 support.)
+      - name: Use Node 24
         uses: actions/setup-node@v4
         with:
-          node-version: 20
+          node-version: 24
           cache: pnpm
           registry-url: https://registry.npmjs.org
-
-      # npm OIDC trusted publishing requires npm >= 11.5.1; Node 20 ships npm 10.x.
-      - name: Upgrade npm for OIDC trusted publishing
-        run: npm install -g npm@latest
 
       - run: pnpm install --frozen-lockfile
 


### PR DESCRIPTION
## Why

The release job has been failing since npm 12 was published ([failed run](https://github.com/boarteam/fix-protocol/actions/runs/29164593820/job/86575414218)):

```
npm error engine Not compatible with your version of node/npm: npm@12.0.1
npm error notsup Required: {"node":"^22.22.2 || ^24.15.0 || >=26.0.0"}
npm error notsup Actual:   {"npm":"10.8.2","node":"v20.20.2"}
```

The workflow pinned Node 20 and ran `npm install -g npm@latest` to satisfy the npm >= 11.5.1 requirement of OIDC trusted publishing. npm 12 dropped Node 20 support, so the unpinned `latest` now fails the engine check before changesets even runs.

## What changed

- **Node 20 → Node 24** for the release job, and the `npm install -g npm@latest` step is removed — Node 24 ships npm >= 11.5.1, so the OIDC requirement is met without a mutable `latest` dependency. (CI still tests the supported 18/20/22 matrix; this only affects the publish environment.)
- **`paths: ['.changeset/**']` filter** on the push trigger, so the job no longer runs on merges that neither add nor consume changesets (docs, CI tweaks). Adding a changeset touches `.changeset/`, and merging the Version Packages PR deletes the consumed changesets there, so both the version-PR and publish phases still trigger exactly when needed.
- **`workflow_dispatch` trigger** as a manual escape hatch, e.g. to retry after a transient failure without waiting for the next changeset.
- Fixed the stale header comment that still claimed an `NPM_TOKEN` secret is required (auth moved to OIDC trusted publishing).

Publishing behavior is unchanged: a release still only happens when the Version Packages PR is merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)