### PR TITLE
chore(api): refresh the API-diff baseline to the released 0.5.0

### DIFF
--- a/packages/fix/api/baseline.json
+++ b/packages/fix/api/baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Structural API of the last published release — regenerate with scripts/refresh-api-baseline.mjs after each release.",
-  "version": "0.4.0",
+  "version": "0.5.0",
   "symbols": [
     {
       "id": "BaseType",


### PR DESCRIPTION
The documented post-release step from [`docs/api-json.md`](docs/api-json.md): re-baseline the API-diff gate on the just-published 0.5.0 surface. No `"next"` since-entries were pending, and 0.5.0 is structurally identical to 0.4.0 — the diff is the version stamp (plus the emitter's array formatting, which prettier re-collapses on commit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)