### PR TITLE
feat(api): doctest @example blocks; api.json declares examplesVerified

### DIFF
--- a/.changeset/api-doctest.md
+++ b/.changeset/api-doctest.md
@@ -1,0 +1,13 @@
+---
+'@boarteam/fix': patch
+---
+
+Doctest the `@example` blocks and say so in the artifact.
+
+Every `@example` in the public doc comments is now an executable claim: the blocks were
+rewritten to be self-contained (real framed wire strings, `// →` output annotations) and
+`examples/api-doctest.test.ts` runs each one verbatim with plain `node` against the built
+workspace packages, asserting the stdout equals the annotations. The emit additionally
+shape-gates every block (exactly one fence, at least one annotation), and `dist/api.json`
+now carries `examplesVerified: true` — the render permission consumers key on before
+showing examples. Additive field; schema stays 1.

--- a/docs/api-json.md
+++ b/docs/api-json.md
@@ -15,6 +15,7 @@ beside is exactly the drift this file exists to rule out.
   "schema": 1,
   "package": "@boarteam/fix",
   "version": "0.5.0",
+  "examplesVerified": true, // every @example executed + output-asserted (≥ 0.5.1)
   "groups": [{ "id": "parse", "title": "Parsing", "symbols": ["parse", "…"] }],
   "symbols": [
     {
@@ -62,10 +63,35 @@ Facts a consumer may rely on:
 | Grouping       | An export is missing from `packages/fix/api/groups.json`, or listed twice. Placement is curation, not a heuristic.                                                                                                                      |
 | Since          | An export has no `packages/fix/api/since.json` entry (`"next"` marks unreleased), or an entry names a non-export.                                                                                                                       |
 | API diff       | The structural surface differs from `packages/fix/api/baseline.json` (the last published release) beyond what the version bump in `package.json` **or a pending changeset** allows: additions need ≥ minor, removals/alterations major. |
+| Doctest        | An `@example` section is not exactly one annotated fence (emit), or the block fails to run / prints something other than its `// → ` annotations (`examples/api-doctest.test.ts`, `pnpm test`).                                         |
 
 Doc-text-only changes pass at any level — prose is not surface. "Structural"
 means: export list, kinds, signatures, parameter names/types/optionality,
 returns, member list/text, and literal-union contents.
+
+## The `@example` doctest (`examplesVerified`)
+
+`@example` blocks are executable claims, held by two gates:
+
+- **Shape, at emit:** each `@example` section is exactly one fenced code block
+  carrying at least one `// → ` output annotation — an example that asserts
+  nothing proves nothing. (Only the line annotation form exists here; a
+  `/* → */` block would close the enclosing JSDoc comment.)
+- **Execution, in CI:** `examples/api-doctest.test.ts` runs every block
+  verbatim with plain `node` from `examples/` (the workspace links make
+  `import '@boarteam/fix'` resolve like a consumer's install) and asserts the
+  stdout equals the annotations line for line.
+
+Authoring rules that follow: blocks are runnable ESM **JavaScript** (node
+executes them un-transpiled — type annotations don't run), self-contained
+(declare your own wire strings; encode them to get correct framing), and
+deterministic (no clocks, no randomness). Prose comments inside a block must
+not begin with `// → ` — that prefix is reserved for asserted output.
+
+`examplesVerified: true` in the artifact is the render permission consumers
+key on: boar.team withholds example rendering from any version that does not
+carry it. The claim's chain of trust is the repo's CI — the doctest gates
+every PR into `main`, and releases build from `main`.
 
 ## Release-time maintenance
 

--- a/examples/api-doctest.test.ts
+++ b/examples/api-doctest.test.ts
@@ -1,0 +1,77 @@
+/* The @example doctest — phase 3 of the generated-API-reference plan, and the
+ * library-side twin of boar.team's tools/fix-docs/verify-samples.mjs.
+ *
+ * Every `@example` block in the public doc comments is EXECUTED here, verbatim,
+ * against the built workspace packages (this directory's node_modules carries
+ * the workspace links, so snippets import '@boarteam/fix' exactly like a
+ * consumer). The `// → ` annotations in a block are asserted outputs: the
+ * snippet's stdout must equal them line for line. A block that does not run,
+ * asserts nothing, or prints something else fails the suite — which is what
+ * lets dist/api.json claim `examplesVerified` and the site render examples.
+ *
+ * Authoring rules (see docs/api-json.md):
+ *   - an @example section is exactly one fenced code block;
+ *   - the code is runnable ESM JavaScript (node runs it un-transpiled);
+ *   - at least one `// → ` annotation per block — an example that asserts
+ *     nothing proves nothing;
+ *   - deterministic output only (no clocks, no randomness).
+ */
+import { spawnSync } from 'node:child_process';
+import { existsSync } from 'node:fs';
+import { dirname, join } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { describe, expect, it } from 'vitest';
+
+// Plain .mjs build tooling — no d.ts; the assertions below are the typing.
+// @ts-expect-error untyped internal script module
+import * as apiModel from '../packages/fix/scripts/api-model.mjs';
+
+const { extractSurface, extractExamples, exampleAnnotations } = apiModel as {
+  extractSurface: () => { symbols: unknown[]; problems: string[] };
+  extractExamples: (symbols: unknown[]) => {
+    examples: { id: string; caption: string; lang: string; code: string }[];
+    problems: string[];
+  };
+  exampleAnnotations: (code: string) => string[];
+};
+
+const EXAMPLES_DIR = dirname(fileURLToPath(import.meta.url));
+const built = existsSync(join(EXAMPLES_DIR, '..', 'packages', 'fix', 'dist', 'index.d.ts'));
+
+const { examples, problems } = built
+  ? (() => {
+      const surface = extractSurface();
+      const extracted = extractExamples(surface.symbols);
+      return {
+        examples: extracted.examples,
+        problems: [...surface.problems, ...extracted.problems],
+      };
+    })()
+  : { examples: [], problems: [] };
+
+describe.skipIf(!built)('@example doctest', () => {
+  it('every @example is a single well-formed fence', () => {
+    expect(problems).toEqual([]);
+    expect(examples.length).toBeGreaterThanOrEqual(2);
+  });
+
+  for (const example of examples) {
+    it(`${example.id}${example.caption ? ` — ${example.caption}` : ''}`, () => {
+      const expected = exampleAnnotations(example.code);
+      expect(expected.length, 'an example must annotate at least one output').toBeGreaterThan(0);
+
+      const res = spawnSync(process.execPath, ['--input-type=module', '--eval', example.code], {
+        cwd: EXAMPLES_DIR,
+        encoding: 'utf8',
+        timeout: 30_000,
+      });
+      expect(res.status, `stderr:\n${res.stderr}`).toBe(0);
+
+      const got = res.stdout
+        .replace(/\n+$/, '')
+        .split('\n')
+        .map((l) => l.trimEnd());
+      expect(got).toEqual(expected.flatMap((a) => a.split('\n')));
+    });
+  }
+});

--- a/packages/fix/scripts/api-model.mjs
+++ b/packages/fix/scripts/api-model.mjs
@@ -396,3 +396,57 @@ export function pendingChangesetLevel(changesetDir = join(REPO_DIR, '.changeset'
 }
 
 export { LEVEL };
+
+/* --------------------------------------------------------------- examples */
+
+/**
+ * Every `@example` block in the surface as a runnable unit: the caption from
+ * the tag line plus the body of the SINGLE fenced code block the section must
+ * consist of. Anything else in the section — stray prose, a second fence, no
+ * fence at all — is a shape problem, and both the emit and the doctest refuse
+ * it: an example that cannot be executed verbatim documents nothing.
+ */
+export function extractExamples(symbols) {
+  const examples = [];
+  const problems = [];
+  const scan = (doc, where) => {
+    const lines = doc.split('\n');
+    let section = null;
+    const sections = [];
+    for (const line of lines) {
+      const tag = /^@([A-Za-z]+)[ \t]*(.*)$/.exec(line);
+      if (tag) {
+        section = tag[1] === 'example' ? { caption: tag[2].trim(), lines: [] } : null;
+        if (section) sections.push(section);
+        continue;
+      }
+      section?.lines.push(line);
+    }
+    sections.forEach((s, i) => {
+      const body = s.lines.join('\n').trim();
+      const fence = /^```([A-Za-z]*)\n([\s\S]*?)\n```$/.exec(body);
+      const id = `${where} @example ${i + 1}`;
+      if (!fence) {
+        problems.push(`${id}: must consist of exactly one fenced code block`);
+        return;
+      }
+      examples.push({ id, where, caption: s.caption, lang: fence[1] || 'ts', code: fence[2] });
+    });
+  };
+  for (const s of symbols) {
+    scan(s.doc, s.id);
+    for (const m of s.members ?? []) scan(m.doc, `${s.id}.${m.name || m.kind}`);
+  }
+  return { examples, problems };
+}
+
+/**
+ * The `// → ` output annotations of an example, in order. Only the line form
+ * exists here — a `/* → *\/` block would close the enclosing JSDoc comment.
+ * The doctest asserts the example's stdout equals these lines exactly.
+ */
+export function exampleAnnotations(code) {
+  const out = [];
+  for (const m of code.matchAll(/\/\/ → (.*)$/gm)) out.push(m[1].trimEnd());
+  return out;
+}

--- a/packages/fix/scripts/emit-api.mjs
+++ b/packages/fix/scripts/emit-api.mjs
@@ -30,6 +30,8 @@ import {
   diffAgainstBaseline,
   pendingChangesetLevel,
   versionDelta,
+  extractExamples,
+  exampleAnnotations,
   LEVEL,
 } from './api-model.mjs';
 
@@ -55,6 +57,19 @@ const { symbols, problems } = extractSurface();
 const coverage = checkDocCoverage(symbols);
 problems.push(...coverage.problems);
 problems.push(...checkLinks(symbols));
+
+/* @example blocks are executable claims: shape-checked here, EXECUTED by
+ * examples/api-doctest.test.ts (the repo's test gate). Both must hold for the
+ * emitted `examplesVerified` flag to mean anything. */
+const doctest = extractExamples(symbols);
+problems.push(...doctest.problems);
+for (const example of doctest.examples) {
+  if (exampleAnnotations(example.code).length === 0) {
+    problems.push(
+      `${example.id}: no \`// → \` output annotations — an example must assert what it prints`,
+    );
+  }
+}
 
 const grouped = new Map();
 for (const group of groups) {
@@ -112,6 +127,10 @@ const api = {
   schema: 1,
   package: pkg.name,
   version: pkg.version,
+  /* Every @example block is shape-gated above and executed with asserted
+   * output by examples/api-doctest.test.ts in this repo's CI — consumers may
+   * render them as verified. Additive field; schema stays 1. */
+  examplesVerified: true,
   groups: groups.map((g) => ({ id: g.id, title: g.title, symbols: g.symbols })),
   symbols: symbols.map((s) => ({
     ...s,
@@ -126,6 +145,7 @@ const withSource = api.symbols.filter((s) => s.source).length;
 console.log(
   `[api] dist/api.json — ${api.symbols.length} symbols · ${groups.length} groups · ` +
     `${withSource}/${api.symbols.length} source-mapped · ` +
+    `${doctest.examples.length} doctested @example block(s) · ` +
     `params documented ${coverage.paramsDocumented}/${coverage.paramsTotal} (reported, not gated)`,
 );
 if (diff.changes.length) {

--- a/packages/fix/src/engine.ts
+++ b/packages/fix/src/engine.ts
@@ -92,21 +92,35 @@ export interface FixEngine<Bodies = Record<string, UntypedBody>> {
  * {@link FixEngine.validate} (see {@link FixIssue.layer}). The returned engine is pure and
  * reusable across messages.
  *
+ * The `// →` annotations below are asserted outputs, not aspirations: every `@example`
+ * block is executed against the built packages by the doctest gate
+ * (examples/api-doctest.test.ts), which fails when a block does not run or does not
+ * print what it claims.
+ *
  * @example
  * ```ts
  * import { createFixEngine } from '@boarteam/fix';
  * import { dictionary } from '@boarteam/fix-dict-fix44';
+ *
  * const fix = createFixEngine(dictionary);
- * const { message, issues } = fix.parse(raw);
+ * const raw = '8=FIX.4.4|9=58|35=A|49=BUY|56=SELL|34=1|52=20260807-12:00:00|98=0|108=30|10=164|';
+ * const { message, issues } = fix.parse(raw, { soh: '|' });
+ * console.log(message.name, issues.length); // → Logon 0
  * ```
  *
  * @example FIXT.1.1 pair (layer-attributed validation)
  * ```ts
+ * import { createFixEngine } from '@boarteam/fix';
  * import { dictionary as fixt11 } from '@boarteam/fix-dict-fixt11';
  * import { dictionary as fix50sp2 } from '@boarteam/fix-dict-fix50sp2';
+ *
  * const fix = createFixEngine({ transport: fixt11, app: fix50sp2 });
- * const issues = fix.validate(fix.parse(raw).message);
- * const sessionFindings = issues.filter((i) => i.layer === 'session'); // → Reject(3)
+ * // A FIXT Logon missing its required EncryptMethod(98) — a session-layer defect,
+ * // so the finding says: answer with a session Reject(3), not a BusinessMessageReject.
+ * const raw = '8=FIXT.1.1|9=60|35=A|49=BUY|56=SELL|34=1|52=20260807-12:00:00|108=30|1137=9|10=079|';
+ * const issues = fix.validate(fix.parse(raw, { soh: '|' }).message);
+ * const sessionFindings = issues.filter((i) => i.layer === 'session');
+ * console.log(sessionFindings.map((i) => `${i.code}(${i.refTagID})`)); // → [ 'validate/required-field-missing(98)' ]
  * ```
  */
 export function createFixEngine<Bodies = Record<string, UntypedBody>>(


### PR DESCRIPTION
Phase 3 of the generated-API-reference plan (boar.team `docs/fix-api-reference.md`): `@example` blocks become executable claims, which is what unlocks example rendering on the site.

## What ships

- **Self-contained examples** — both `createFixEngine` blocks rewritten with real framed wire (a FIX 4.4 Logon; a FIXT-pair Logon missing its required `EncryptMethod(98)`, demonstrating session-layer attribution) and `// →` output annotations. The annotated outputs were produced by the engine, then pinned.
- **The doctest gate** — [`examples/api-doctest.test.ts`](examples/api-doctest.test.ts) extracts every `@example` from the built surface and executes it verbatim (`node --input-type=module --eval`, cwd `examples/` so workspace links resolve like a consumer install), asserting stdout equals the annotations line for line. Plus a shape gate at emit: exactly one fence per section, at least one annotation.
- **`examplesVerified: true` in `dist/api.json`** — the render permission the site keys on; versions without it keep examples withheld. Additive field, schema stays 1; authoring rules in [`docs/api-json.md`](docs/api-json.md).

## Verification

`pnpm test` 556 passing (3 new doctest cases), emit reports "2 doctested @example block(s)", surface identical to the 0.5.0 baseline (doc-text only), typecheck/lint/format/bundle green. Carries a patch changeset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)