### PR TITLE
docs: point the repo at the boar.team documentation site

### DIFF
--- a/.changeset/docs-site-links.md
+++ b/.changeset/docs-site-links.md
@@ -1,0 +1,15 @@
+---
+'@boarteam/fix': patch
+'@boarteam/fix-dict-fix44': patch
+'@boarteam/fix-dict-fix42': patch
+'@boarteam/fix-dict-fix50sp2': patch
+'@boarteam/fix-dict-fixt11': patch
+---
+
+Point readers at the documentation site.
+
+Every package now advertises <https://boar.team/fix/docs/> as its `homepage` (npm renders it as
+the package's primary link) and opens its README with a docs / API-reference / playground row.
+The engine README gains a section listing the six guides, the generated API reference, the issue-code
+diagnostics catalogue and the browsable FIX dictionary reference; each dictionary README links the
+reference view for its own dialect. Docs-only — no code, types, or dictionary data changed.

--- a/.github/ISSUE_TEMPLATE/config.yml
+++ b/.github/ISSUE_TEMPLATE/config.yml
@@ -1,5 +1,8 @@
 blank_issues_enabled: false
 contact_links:
+  - name: Documentation
+    url: https://boar.team/fix/docs/
+    about: Guides, the generated API reference, the issue-code catalogue and a browser playground.
   - name: Security report
     url: https://github.com/boarteam/fix-protocol/security/advisories/new
     about: Please report vulnerabilities privately. See SECURITY.md — do not open a public issue.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,15 @@ check that fails any PR commit lacking a `Signed-off-by:` trailer. So:
 A `pre-commit` hook (simple-git-hooks → lint-staged → prettier) reformats staged files,
 so expect a reformat pass on commit.
 
+## Where the docs live
+
+User-facing documentation is published at <https://boar.team/fix/docs/> (guides, the generated
+API reference at `/fix/docs/api/`, the issue-code catalogue at `/fix/diagnostics/`, the playground
+at `/fix/playground/`, and the browsable dictionary reference at `/fix/`). The site is built from a
+separate repository; this repo owns the two generated inputs — the TSDoc comments behind
+`dist/api.json` and the shipped issue-code catalogue. READMEs and `package.json` `homepage` fields
+point there, so keep new links consistent with that set.
+
 ## Repo shape
 
 pnpm workspace, vitest, TypeScript. Packages under `packages/`: `fix` (the engine),

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -90,6 +90,24 @@ submit the contribution under the project's license. CI enforces this on every P
 Commit messages follow [Conventional Commits](https://www.conventionalcommits.org/)
 (`feat:`, `fix:`, `docs:`, `chore:`, with an optional scope like `feat(parse):`).
 
+## Documentation
+
+User-facing documentation — the guides, the generated API reference, the issue-code catalogue,
+the playground and the browsable dictionary reference — lives at
+<https://boar.team/fix/docs/>. Two parts of it are produced **from this repository**, so they are
+contributed here:
+
+- **The [API reference](https://boar.team/fix/docs/api/)** is rendered from `dist/api.json`, which
+  the `packages/fix` build extracts from the TSDoc comments on the public exports. Improving an
+  export's docs means editing its doc comment in `packages/fix/src` — CI already fails on an
+  undocumented export or a broken `{@link}`. See [`docs/api-json.md`](docs/api-json.md).
+- **The [diagnostics catalogue](https://boar.team/fix/diagnostics/)** lists every issue code the
+  engine ships; the list itself comes from the released package, so a new or renamed code lands
+  there automatically (the site's build fails until its prose covers it).
+
+The prose guides are authored in the site's own repository. If one is wrong or missing something,
+open an [issue](https://github.com/boarteam/fix-protocol/issues) here and we will route it.
+
 ## Reporting bugs & security issues
 
 Use the issue templates for bugs and features. For **security vulnerabilities**, do not open a

--- a/README.md
+++ b/README.md
@@ -4,8 +4,11 @@
 
 [![npm version](https://img.shields.io/npm/v/@boarteam/fix.svg)](https://www.npmjs.com/package/@boarteam/fix)
 [![CI](https://github.com/boarteam/fix-protocol/actions/workflows/ci.yml/badge.svg)](https://github.com/boarteam/fix-protocol/actions/workflows/ci.yml)
+[![docs](https://img.shields.io/badge/docs-boar.team%2Ffix-0a7ea4)](https://boar.team/fix/docs/)
 [![dependencies](https://img.shields.io/badge/dependencies-0-brightgreen)](#why-zero-dependencies-matters)
 [![license](https://img.shields.io/npm/l/@boarteam/fix.svg)](LICENSE)
+
+📖 **[Documentation](https://boar.team/fix/docs/)** · 🧭 **[API reference](https://boar.team/fix/docs/api/)** · ▶️ **[Playground](https://boar.team/fix/playground/)** · 📚 **[FIX reference](https://boar.team/fix/)**
 
 <p align="center">
   <img src=".github/demo.gif" width="900" alt="Terminal recording: a raw FIX 4.4 log line is piped into @boarteam/fix and decoded in narrated stages — named, typed fields, the NoMDEntries repeating group expanded into nested Bid/Offer objects, then a clean parse + validate verdict. Next a corrupted Execution Report is piped in and still parses without throwing: the bad float, wrong checksum, and invalid OrdStatus enum all come back as structured diagnostics from parse() and validate(). The same pure engine runs unchanged in a browser tab or in Node.">
@@ -84,7 +87,7 @@ The decoded `message` — note the `268` repeating group is an **array of nested
 // ...plus validate/required-field-missing for any absent required fields.
 ```
 
-That is the whole pitch: paste a message, get the structure and every defect, in the browser, with zero dependencies. No socket, no sequence numbers, no `connect()`.
+That is the whole pitch: paste a message, get the structure and every defect, in the browser, with zero dependencies. No socket, no sequence numbers, no `connect()`. Try it without installing anything — the [playground](https://boar.team/fix/playground/) runs this engine client-side; the guides and API reference are at [boar.team/fix/docs](https://boar.team/fix/docs/).
 
 ---
 
@@ -128,6 +131,30 @@ Swap in `@boarteam/fix-dict-fix42` for FIX 4.2, or `@boarteam/fix-dict-fix50sp2`
 
 ---
 
+## Documentation
+
+The full documentation lives at **[boar.team/fix/docs](https://boar.team/fix/docs/)** — every code sample on it is compiled and executed against the released package at build time, so the docs cannot drift from the library.
+
+| Guide                                                        | What it covers                                                                                 |
+| ------------------------------------------------------------ | ---------------------------------------------------------------------------------------------- |
+| [Parse](https://boar.team/fix/docs/parse/)                   | `parse` / `parseAll`, raw vs typed values, repeating groups, pipe-delimited logs, never-throws |
+| [Validate](https://boar.team/fix/docs/validate/)             | The `FixIssue` shape, stable issue codes as the SemVer contract, severities, layers            |
+| [Encode](https://boar.team/fix/docs/encode/)                 | Tag-keyed encode, dictionary field order, byte-accurate `BodyLength` / `CheckSum`              |
+| [Typed messages](https://boar.team/fix/docs/typed-messages/) | The `message()` builder, compile-error safety, `render()`, immutability, type guards           |
+| [Extend a dictionary](https://boar.team/fix/docs/extend/)    | Venue-custom tags with `defineExtension` — cTrader's `1007`/`1008` as the worked example       |
+| [Dictionaries](https://boar.team/fix/docs/dictionaries/)     | Choosing FIX 4.4, 4.2 or 5.0 SP2, the FIXT pair API, free functions and output shapes          |
+
+Alongside the guides:
+
+- **[API reference](https://boar.team/fix/docs/api/)** — every export, signature by signature, generated from the `dist/api.json` model this package ships (see [`docs/api-json.md`](docs/api-json.md)), with source links and a "since" badge per export.
+- **[Diagnostics catalogue](https://boar.team/fix/diagnostics/)** — every `parse/*`, `validate/*`, `dict/*` and `extend/*` issue code the engine can emit, each with its usual cause. Build-time checked against the installed package, so it is never out of date.
+- **[Playground](https://boar.team/fix/playground/)** — paste a raw message and decode it in the browser, running this engine client-side.
+- **[FIX reference](https://boar.team/fix/)** — the browsable dictionary behind it all: [tags](https://boar.team/fix/tags/), [messages](https://boar.team/fix/messages/), [components](https://boar.team/fix/components/), [datatypes](https://boar.team/fix/datatypes/), and per-dialect views for [FIX 4.4](https://boar.team/fix/dialect/4-4/), [FIX 4.2](https://boar.team/fix/dialect/4-2/) and [FIX 5.0 SP2](https://boar.team/fix/dialect/5-0-sp2/).
+
+The rest of this README is the short tour.
+
+---
+
 ## Usage
 
 ### Create an engine
@@ -168,6 +195,8 @@ for (const entry of message.groups[268] ?? []) {
 
 Use `parseAll` for a stream of concatenated messages (e.g. a log file).
 
+→ Full guide: [Parsing FIX messages](https://boar.team/fix/docs/parse/).
+
 ### Validate
 
 `validate` checks presence (required fields), enum membership, datatypes, and conditional-required rules against the dictionary, returning a `FixIssue[]`:
@@ -180,6 +209,8 @@ for (const issue of problems) {
 ```
 
 Every `FixIssue` carries a **stable `code`** (e.g. `validate/value-not-in-enum`, `parse/checksum-mismatch`), a `severity` (`error | warning | info`), a human `message`, and — where relevant — a `path`, `refTagID`, `refSeqNum`, `refMsgType`, or `sessionRejectReason`. The codes are part of the SemVer contract; the human message is not.
+
+→ Full guide: [Validating FIX messages](https://boar.team/fix/docs/validate/). Every issue code the engine can emit is catalogued, with its usual cause, in the [diagnostics reference](https://boar.team/fix/diagnostics/).
 
 ### Encode
 
@@ -205,6 +236,8 @@ const wire = fix.encode({
 ```
 
 `encode` emits fields in dictionary order and computes `BeginString (8)`, `BodyLength (9)`, and `CheckSum (10)` byte-accurately. It is pure — **you** supply the session fields (sequence number, sending time); the engine never invents them.
+
+→ Full guide: [Encoding FIX messages](https://boar.team/fix/docs/encode/).
 
 ### Typed messages
 
@@ -242,6 +275,8 @@ if (isMessageType(message, MsgType.MarketDataSnapshotFullRefresh)) {
   }
 }
 ```
+
+→ Full guide: [Typed messages](https://boar.team/fix/docs/typed-messages/).
 
 ### Reading pipe-delimited logs
 
@@ -311,9 +346,13 @@ a package that emits `.d.ts` — annotate the exports with the provided alias ty
 instead of structurally inlining the 900-key base map. The same pattern scales to publishable
 venue packages (e.g. a future `@boarteam/fix-dict-fix44-ctrader`).
 
+→ Full guide: [Extending a dictionary](https://boar.team/fix/docs/extend/).
+
 ### Lower-level building blocks
 
 If you do not want the engine wrapper, the same capabilities are exported as free functions: `parse`, `parseAll`, `encode`, `validate`, `tokenize`, `splitMessages`, `decodeValue`, `calculateChecksum`, `bodyLength`, `loadDictionary`, `Dictionary`, `validateDictionary`, the typed-message helpers (`messageFactory`, `messageTypeGuard`, `createMessage`, `createImmutableMessage`), and the dictionary-extension helpers (`extendDictionary`, `defineExtension`, `tagsOf`, `msgTypesOf`, `extendTags`, `invertTags`, `extendMsgTypes`, `invertMsgTypes`).
+
+Every one of them is documented, signature by signature, in the [API reference](https://boar.team/fix/docs/api/).
 
 ### Output shapes
 
@@ -332,7 +371,7 @@ For a library that sits in a trading firm's toolchain, the dependency tree _is_ 
 
 ## Coverage & correctness
 
-The dictionaries ship as data, generated by the separate `@boarteam/fix-codegen` generator from permissively-licensed sources. The counts below are read directly from the shipped dictionary files.
+The dictionaries ship as data, generated by the separate `@boarteam/fix-codegen` generator from permissively-licensed sources. The counts below are read directly from the shipped dictionary files, and each dialect is browsable field-by-field on the [FIX reference](https://boar.team/fix/dialects/) — the [coverage page](https://boar.team/fix/coverage/) renders the declared gaps below from the same shipped data.
 
 ### FIX 4.4 — `@boarteam/fix-dict-fix44`
 
@@ -389,6 +428,8 @@ What it owns instead: decoding and validating messages you already have, encodin
 | [`@boarteam/fix-dict-fixt11`](https://www.npmjs.com/package/@boarteam/fix-dict-fixt11)     | 1.0.0   | FIXT.1.1 transport-only dictionary (envelope + session messages), for the pair API.            |
 
 All packages: zero runtime dependencies, dual ESM + CJS, Node ≥ 18, browser + Node, Apache-2.0. The dictionary packages also export `dictionary`, `Tags` (name → tag), `MsgType` (name → msgtype), and `DICTIONARY_VERSION` (e.g. `"FIX.4.4"`, `"FIX.5.0SP2"`).
+
+Which dictionary to pick, and how the FIXT pair fits together: [Dictionaries guide](https://boar.team/fix/docs/dictionaries/). To browse the data itself before installing anything, each dialect has a reference view — [FIX 4.4](https://boar.team/fix/dialect/4-4/), [FIX 4.2](https://boar.team/fix/dialect/4-2/), [FIX 5.0 SP2](https://boar.team/fix/dialect/5-0-sp2/) — and there is a [4.4 vs 4.2 diff](https://boar.team/fix/4-4-vs-4-2/).
 
 ---
 

--- a/packages/fix-dict-fix42/README.md
+++ b/packages/fix-dict-fix42/README.md
@@ -5,6 +5,8 @@ The **complete FIX 4.2 dictionary as data** (405 fields / 46 messages / 21 datat
 official FIX 4.2 specification (FIX Repository, 2010 Edition) and cross-checked against the
 QuickFIX `FIX42.xml` dictionary by a CI drift gate — never hand-maintained.
 
+📖 **[Documentation](https://boar.team/fix/docs/)** · 📚 **[Browse FIX 4.2](https://boar.team/fix/dialect/4-2/)** · ▶️ **[Playground](https://boar.team/fix/playground/)** · 💻 **[GitHub](https://github.com/boarteam/fix-protocol)**
+
 Stable and actively developed. See the
 [project README](https://github.com/boarteam/fix-protocol#readme) for coverage, the cross-check
 report, and declared coverage gaps.
@@ -32,8 +34,8 @@ It also exports the typed encode-side API: `message` (a factory bound to this di
 plus augmentable per-container group/component `interface`s. For the read side it exports
 `isMessageType` (a type guard that narrows a `MessageView<any>` of unknown type to a specific
 message's body, keyed on its `MsgType` value) and `MessageOf<M>` (the matching annotation alias).
-See the [`@boarteam/fix` README](https://www.npmjs.com/package/@boarteam/fix) for the
-typed-message API.
+The typed-message API is documented in full in the
+[Typed messages guide](https://boar.team/fix/docs/typed-messages/).
 
 Requires `@boarteam/fix` as a peer dependency.
 

--- a/packages/fix-dict-fix42/package.json
+++ b/packages/fix-dict-fix42/package.json
@@ -37,7 +37,7 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix-dict-fix42"
   },
-  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "homepage": "https://boar.team/fix/docs/",
   "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/fix-dict-fix44/README.md
+++ b/packages/fix-dict-fix44/README.md
@@ -4,6 +4,8 @@ The **complete FIX 4.4 dictionary as data** (912 fields / 93 messages / 105 comp
 datatypes) for the [`@boarteam/fix`](https://www.npmjs.com/package/@boarteam/fix) engine.
 Generated directly from the QuickFIX `FIX44.xml` data dictionary — never hand-maintained.
 
+📖 **[Documentation](https://boar.team/fix/docs/)** · 📚 **[Browse FIX 4.4](https://boar.team/fix/dialect/4-4/)** · ▶️ **[Playground](https://boar.team/fix/playground/)** · 💻 **[GitHub](https://github.com/boarteam/fix-protocol)**
+
 Stable and actively developed. See the
 [project README](https://github.com/boarteam/fix-protocol#readme) for coverage and declared
 coverage gaps.
@@ -50,8 +52,8 @@ group/component `interface`s (`SecListGrp_NoRelatedSymEntry`, `InstrumentFields`
 extensions patch via declaration merging. For the read side it exports `isMessageType` — a type
 guard that narrows a `MessageView<any>` of unknown type to a specific message's body keyed on its
 `MsgType` value (so `get()` becomes typed) — and `MessageOf<M>`, the matching annotation alias.
-See the [`@boarteam/fix` README](https://www.npmjs.com/package/@boarteam/fix) for the
-typed-message API.
+The typed-message API is documented in full in the
+[Typed messages guide](https://boar.team/fix/docs/typed-messages/).
 
 Requires `@boarteam/fix` as a peer dependency.
 

--- a/packages/fix-dict-fix44/package.json
+++ b/packages/fix-dict-fix44/package.json
@@ -37,7 +37,7 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix-dict-fix44"
   },
-  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "homepage": "https://boar.team/fix/docs/",
   "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/fix-dict-fix50sp2/README.md
+++ b/packages/fix-dict-fix50sp2/README.md
@@ -9,6 +9,8 @@ same single-dictionary API the 4.2/4.4 dicts use. Generated from the QuickFIX/J
 `FIX50SP2.xml` + `FIXT11.xml` data dictionaries and cross-checked against quickfix-go's
 independently-maintained `FIX50SP2.xml` by a CI drift gate — never hand-maintained.
 
+📖 **[Documentation](https://boar.team/fix/docs/)** · 📚 **[Browse FIX 5.0 SP2](https://boar.team/fix/dialect/5-0-sp2/)** · ▶️ **[Playground](https://boar.team/fix/playground/)** · 💻 **[GitHub](https://github.com/boarteam/fix-protocol)**
+
 FIX 5.0 messages travel over FIXT.1.1: tag 8 carries `FIXT.1.1`, and the application
 version rides on `DefaultApplVerID(1137)` (required on Logon; `9` = FIX 5.0 SP2) with the
 optional per-message header override `ApplVerID(1128)`. This dictionary models exactly

--- a/packages/fix-dict-fix50sp2/package.json
+++ b/packages/fix-dict-fix50sp2/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix-dict-fix50sp2"
   },
-  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "homepage": "https://boar.team/fix/docs/",
   "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/fix-dict-fixt11/README.md
+++ b/packages/fix-dict-fixt11/README.md
@@ -9,6 +9,8 @@ TestRequest(1), ResendRequest(2), Reject(3), SequenceReset(4), Logout(5), and Lo
 with its required `DefaultApplVerID(1137)`. Generated from the QuickFIX/J `FIXT11.xml`
 data dictionary — never hand-maintained.
 
+📖 **[Documentation](https://boar.team/fix/docs/)** · 🔀 **[The FIXT pair API](https://boar.team/fix/docs/dictionaries/)** · ▶️ **[Playground](https://boar.team/fix/playground/)** · 💻 **[GitHub](https://github.com/boarteam/fix-protocol)**
+
 Use it for transport-layer tooling (session-message construction and validation, layer
 attribution) or pair it with an application dictionary. For a batteries-included FIX 5.0
 SP2 dictionary that already contains this envelope, use

--- a/packages/fix-dict-fixt11/package.json
+++ b/packages/fix-dict-fixt11/package.json
@@ -39,7 +39,7 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix-dict-fixt11"
   },
-  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "homepage": "https://boar.team/fix/docs/",
   "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"

--- a/packages/fix/README.md
+++ b/packages/fix/README.md
@@ -5,6 +5,8 @@ A **dictionary-driven FIX protocol toolkit** for TypeScript — parse, validate,
 or Node. This is the engine; pair it with a dictionary such as
 [`@boarteam/fix-dict-fix44`](https://www.npmjs.com/package/@boarteam/fix-dict-fix44).
 
+📖 **[Documentation](https://boar.team/fix/docs/)** · 🧭 **[API reference](https://boar.team/fix/docs/api/)** · ▶️ **[Playground](https://boar.team/fix/playground/)** · 💻 **[GitHub](https://github.com/boarteam/fix-protocol)**
+
 On a 0.x line: the foundation is solid and well-tested, and the API may still refine ahead of
 1.0. See the [project README](https://github.com/boarteam/fix-protocol#readme) for coverage,
 testing, and the roadmap — [feedback](https://github.com/boarteam/fix-protocol/issues) welcome.
@@ -114,7 +116,7 @@ patch the shared interface via declaration merging (single venue) or an override
 intersection (multiple venues), then rebind `messageFactory<MessageBodies>(extended)`. The
 augmented type and the extended dictionary ship as a pair.
 
-Full docs, examples, and the contribution guide are in the
+Examples and the contribution guide live in the
 [monorepo](https://github.com/boarteam/fix-protocol).
 
 ## FIX 5.0 SP2 / FIXT.1.1
@@ -145,7 +147,21 @@ pair pre-merged (a drop-in for `createFixEngine(dictionary)`), and
 `mergeFixtDictionaries(transport, app)` builds the same shape from your own app-layer
 dialect.
 
-## API reference & `dist/api.json`
+## Documentation
+
+The full documentation is at **[boar.team/fix/docs](https://boar.team/fix/docs/)** — guides for
+[parsing](https://boar.team/fix/docs/parse/), [validation](https://boar.team/fix/docs/validate/),
+[encoding](https://boar.team/fix/docs/encode/),
+[typed messages](https://boar.team/fix/docs/typed-messages/),
+[dictionary extensions](https://boar.team/fix/docs/extend/) and
+[choosing a dictionary](https://boar.team/fix/docs/dictionaries/). Every sample on those pages is
+compiled and executed against the released package at build time, so they cannot drift from what
+you install. Alongside them: a [catalogue of every issue code](https://boar.team/fix/diagnostics/)
+`parse` and `validate` can emit, a browser
+[playground](https://boar.team/fix/playground/) running this engine client-side, and a browsable
+[FIX dictionary reference](https://boar.team/fix/).
+
+### API reference & `dist/api.json`
 
 Every export is documented, signature by signature, in the generated
 [API reference](https://boar.team/fix/docs/api/), and the tarball ships the model it is

--- a/packages/fix/package.json
+++ b/packages/fix/package.json
@@ -40,7 +40,7 @@
     "url": "git+https://github.com/boarteam/fix-protocol.git",
     "directory": "packages/fix"
   },
-  "homepage": "https://github.com/boarteam/fix-protocol#readme",
+  "homepage": "https://boar.team/fix/docs/",
   "bugs": "https://github.com/boarteam/fix-protocol/issues",
   "publishConfig": {
     "access": "public"


### PR DESCRIPTION
## What & why

The guides, generated API reference, issue-code catalogue and playground are now published at
[boar.team/fix/docs](https://boar.team/fix/docs/), but nothing in this repo said so — the only
link anywhere was a single mention of `/fix/docs/api/` in `packages/fix/README.md`. This makes the
docs findable from every place a visitor actually lands.

| Landing point | What they now see |
| --- | --- |
| GitHub repo page | A `docs` badge, a **Documentation · API reference · Playground · FIX reference** row under the badges, a `## Documentation` section after Install listing the six guides plus the four reference surfaces, and a "→ Full guide" pointer closing each Usage subsection |
| npm package page | `homepage` → `https://boar.team/fix/docs/` on all five published packages (npm renders it as the primary link; the GitHub link stays as the `repository` field), and the same link row atop each README — the dictionary ones deep-linking their own dialect view |
| "New issue" screen | A **Documentation** contact link above the security/discussion ones |
| `CONTRIBUTING.md` | Which parts of the docs are generated *from this repo* — the TSDoc behind `dist/api.json`, and the shipped issue-code catalogue — so doc fixes land in the right place |

`CLAUDE.md` gets a matching note so future changes keep the link set consistent.

## Type of change

- [ ] Bug fix (parse/validate/encode/dictionary)
- [ ] New feature
- [x] Docs / examples
- [ ] Tooling / CI
- [ ] Breaking change (output shape, accepted input, or issue codes — see SECURITY/CHANGELOG policy)

## Checklist

- [ ] `pnpm -r build && pnpm -r typecheck` pass — not run (no source, config, or type changes; see note below)
- [x] `pnpm lint && pnpm format:check` pass — Prettier run over every touched file, `--check` clean
- [ ] `pnpm test` passes (Node + browser-like env, examples) — not run; no test-reachable change
- [ ] `pnpm check:bundle` passes — not run; published *output* is untouched (only the `homepage` field in the manifests)
- [x] Added a Changeset if this changes a published package (`pnpm changeset`) — patch, all five packages, since the `homepage` change ships in the tarballs
- [x] Dictionary data (`fix-dict-fix44`) was **regenerated** with the spec tooling, not hand-edited — n/a, no dictionary data touched
- [x] Commits are signed off (`git commit -s`) per the DCO

## Notes for reviewers

- **All 21 `boar.team` URLs added here were checked for a 200** before committing, including the
  three dialect views, whose slugs are `4-4` / `4-2` / `5-0-sp2` (not the package ids). There is no
  reference page for FIXT.1.1, so `fix-dict-fixt11`'s README links the Dictionaries guide instead.
- **The gates were not run locally** — this branch changes only Markdown plus one string per
  manifest, and the environment had no installed workspace. CI is the check that matters here.
- **Two claims in the new prose are load-bearing**, and both were verified against the site's
  sources rather than assumed: docs samples are compiled *and executed* against the released
  package (`tools/fix-docs/verify-samples.mjs`, wired into `prebuild`), and the diagnostics page
  fails its build on any drift from the shipped issue-code catalogue.
- **The site repo is private**, so nothing here links to it; `CONTRIBUTING.md` routes doc-prose
  reports through this repo's issue tracker instead.
- **Still open, and outside what I can do from here:** the repo's **About → Website** field is
  empty. That sidebar link is the most visible spot on the repo page and is worth pointing at
  `https://boar.team/fix/docs/`.


---
_Generated by [Claude Code](https://claude.ai/code/session_01B1YKLpdSMFJzdxvz2w5Z7H)_