### PR TITLE
chore(release): stop dictionaries from taking a major bump per engine release

### DIFF
--- a/.changeset/config.json
+++ b/.changeset/config.json
@@ -7,5 +7,8 @@
   "access": "public",
   "baseBranch": "main",
   "updateInternalDependencies": "patch",
-  "ignore": ["@boarteam/fix-examples"]
+  "ignore": ["@boarteam/fix-examples"],
+  "___experimentalUnsafeOptions_WILL_CHANGE_IN_PATCH": {
+    "onlyUpdatePeerDependentsWhenOutOfRange": true
+  }
 }

--- a/.changeset/dict-independent-versioning.md
+++ b/.changeset/dict-independent-versioning.md
@@ -1,0 +1,21 @@
+---
+'@boarteam/fix-dict-fix44': patch
+'@boarteam/fix-dict-fix42': patch
+'@boarteam/fix-dict-fix50sp2': patch
+'@boarteam/fix-dict-fixt11': patch
+---
+
+Stop the dictionaries from taking a major bump on every engine release.
+
+Each dictionary declared `@boarteam/fix` as `workspace:^`, published as `^0.5.0` — a range that
+in 0.x admits patches only. Every engine minor therefore left it, and Changesets bumps a peer
+dependent whose range is left to **major**, so the dictionaries climbed a major per engine
+release (`fix44` reached 4.0.0 against an engine at 0.5.0) carrying nothing but an "Updated
+dependencies" line.
+
+The peer range now spans the whole pre-1.0 engine line — `">=0.5.0 <1.0.0"` — so an engine
+release stays inside it, and `onlyUpdatePeerDependentsWhenOutOfRange` limits the forced major to
+peers whose range a new version actually leaves. From here each dictionary versions on its own
+changes: a regenerated dictionary, a new export, a corrected field — or an engine change that
+genuinely breaks it, which gets its own changeset. Published data, types, and exports are
+unchanged; the only difference in the tarball is the wider peer range.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,18 @@ While the project is pre-1.0, the public contract under SemVer covers:
 A breaking change to any of these is released as a **minor** bump (0.x → 0.(x+1)) and called
 out in the changeset. Additive changes and fixes are patch bumps.
 
+### Dictionary packages version independently
+
+The `@boarteam/fix-dict-*` packages carry their own version line, tracking changes to _their own_
+data and generated types — a regenerated dictionary, a new export, a corrected field. They are
+**not** re-released just because the engine was, and their version number is not expected to
+resemble the engine's.
+
+Each dictionary declares the engine as a peer dependency over the whole pre-1.0 line
+(`">=0.5.0 <1.0.0"`), so an engine release stays inside the range and needs no dictionary
+republish. If an engine change genuinely breaks a dictionary, that dictionary gets its own
+changeset saying so.
+
 ## Unreleased
 
 - **FIX 5.0 SP2 / FIXT.1.1 support** (engine minor + two new dictionary packages):

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -42,3 +42,7 @@ contract (doc coverage, `{@link}` integrity, curated grouping, since-map, API di
 the last release — see `docs/api-json.md`); an API-changing PR needs a changeset of
 the matching level, and a new export must be placed in `packages/fix/api/groups.json`
 and `api/since.json` (`"next"`).
+
+Packages version independently. Name a `fix-dict-*` package in a changeset only when that
+dictionary itself changed — an engine release must not bump the dictionaries. See
+[`CONTRIBUTING.md`](./CONTRIBUTING.md) § "Changesets (versioning)".

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -60,6 +60,16 @@ pnpm changeset
 Pre-1.0 SemVer: breaking changes to the **output shape**, **accepted input**, or **issue
 codes** are a minor bump and must be called out in the changeset. See `CHANGELOG.md`.
 
+Each package versions on its own changes. The dictionaries do **not** ride along with an engine
+release: they declare `@boarteam/fix` as a peer dependency over the whole pre-1.0 line
+(`">=0.5.0 <1.0.0"`), which every engine release stays inside, so releasing the engine leaves
+them untouched. Name a dictionary in your changeset only when that dictionary actually changed
+— including when an engine change breaks it. (Changesets would otherwise force a **major** bump
+on every peer dependent of a released package; `onlyUpdatePeerDependentsWhenOutOfRange` in
+`.changeset/config.json` limits that to peers whose range the new version actually leaves.
+When the engine does reach 1.0, that major bump fires as intended — check the Version Packages
+PR, which rewrites the peer range to a bare `>=1.0.0`, and restore the upper bound by hand.)
+
 ## Releasing (maintainers)
 
 Releases are automated by the [Release workflow](.github/workflows/release.yml) using the

--- a/packages/fix-dict-fix42/package.json
+++ b/packages/fix-dict-fix42/package.json
@@ -46,7 +46,7 @@
     "node": ">=18"
   },
   "peerDependencies": {
-    "@boarteam/fix": "workspace:^"
+    "@boarteam/fix": ">=0.5.0 <1.0.0"
   },
   "devDependencies": {
     "@boarteam/fix": "workspace:*",

--- a/packages/fix-dict-fix44/package.json
+++ b/packages/fix-dict-fix44/package.json
@@ -46,7 +46,7 @@
     "node": ">=18"
   },
   "peerDependencies": {
-    "@boarteam/fix": "workspace:^"
+    "@boarteam/fix": ">=0.5.0 <1.0.0"
   },
   "devDependencies": {
     "@boarteam/fix": "workspace:*",

--- a/packages/fix-dict-fix50sp2/package.json
+++ b/packages/fix-dict-fix50sp2/package.json
@@ -49,7 +49,7 @@
     "node": ">=18"
   },
   "peerDependencies": {
-    "@boarteam/fix": "workspace:^"
+    "@boarteam/fix": ">=0.5.0 <1.0.0"
   },
   "devDependencies": {
     "@boarteam/fix": "workspace:*",

--- a/packages/fix-dict-fixt11/package.json
+++ b/packages/fix-dict-fixt11/package.json
@@ -48,7 +48,7 @@
     "node": ">=18"
   },
   "peerDependencies": {
-    "@boarteam/fix": "workspace:^"
+    "@boarteam/fix": ">=0.5.0 <1.0.0"
   },
   "devDependencies": {
     "@boarteam/fix": "workspace:*",


### PR DESCRIPTION
## What & why

The `@boarteam/fix-dict-*` packages climbed a **major version on every `@boarteam/fix` release** —
`fix44` is at 4.0.0 against an engine at 0.5.0, and its changelog entries read `## 4.0.0` /
`### Patch Changes` / "Updated dependencies": a major with nothing in it.

Two independent causes stacked:

1. Each dictionary declared `"@boarteam/fix": "workspace:^"` as a **peerDependency**, which pnpm
   publishes as `^0.5.0` — and in 0.x a caret admits patches only. Every engine minor left that range.
2. Changesets bumps a peer dependent to **major** whenever its dependency takes a non-patch bump —
   by default *unconditionally*, whether or not the range was actually left
   (`shouldBumpMajor` in `@changesets/assemble-release-plan`).

Both are fixed here:

- **`.changeset/config.json`** — `onlyUpdatePeerDependentsWhenOutOfRange: true`, so the forced major
  fires only for peers whose range a new version genuinely leaves.
- **The four dict `package.json` files** — peer range widened from `workspace:^` to
  `">=0.5.0 <1.0.0"`, spanning the whole pre-1.0 engine line.

Both were required: with the flag alone, `^0.5.0` still excludes `0.6.0`, so the major would still fire.

## Verification

Ran `changeset version` on isolated copies of the tree (repo's own pending changesets removed so each
case is clean). Before the fix, an engine minor drove the dictionaries to 5.0.0 / 3.0.0.

| pending changeset | engine | dictionaries |
| --- | --- | --- |
| engine **minor** | 0.5.0 → 0.6.0 | untouched |
| engine **patch** | 0.5.0 → 0.5.1 | untouched |
| engine **major** | 0.5.0 → 1.0.0 | major — correct, the range is genuinely left |
| dict-only minor | untouched | only that dict, 4.0.0 → 4.1.0 |

`pnpm pack` confirms the literal range ships verbatim in the published manifest
(`"peerDependencies": {"@boarteam/fix": ">=0.5.0 <1.0.0"}`), and `pnpm install --frozen-lockfile`
is unaffected — peer specs for workspace packages aren't recorded in the lockfile, and the local
`workspace:*` devDependency still satisfies the peer, so `packages/*/node_modules/@boarteam/fix`
stays a symlink to the workspace copy.

## Type of change

- [ ] Bug fix (parse/validate/encode/dictionary)
- [ ] New feature
- [x] Docs / examples
- [x] Tooling / CI
- [ ] Breaking change (output shape, accepted input, or issue codes — see SECURITY/CHANGELOG policy)

## Checklist

- [x] `pnpm -r build && pnpm -r typecheck` pass
- [x] `pnpm lint && pnpm format:check` pass
- [x] `pnpm test` passes (Node + browser-like env, examples) — 556 tests, 44 files
- [x] `pnpm check:bundle` passes (no `net`/`Buffer`/`crypto`/`joi`/`@nestjs` in published output)
- [x] Added a Changeset if this changes a published package (`pnpm changeset`)
- [x] Dictionary data (`fix-dict-fix44`) was **regenerated** with the spec tooling, not hand-edited — n/a, no dictionary data touched
- [x] Commits are signed off (`git commit -s`) per the DCO — see CONTRIBUTING.md

## Notes for reviewers

**The published 4.0.0 / 2.0.0 versions can't be walked back.** The dictionaries keep their current
numbers and diverge from here — `fix44` goes to 4.0.1 next, it does not return to somewhere near the
engine's line. That divergence is the intended end state: each package versions on its own changes.

**One wart at the 1.0 boundary.** When the engine reaches 1.0 the dictionaries take a major bump (correct
— the range is genuinely left), but Changesets rewrites the peer range through `getVersionRangeType`,
which maps `">=0.5.0 <1.0.0"` to the `">="` prefix and yields a bare `">=1.0.0"`, dropping the upper
bound. That needs a manual fix in the Version Packages PR; the note is in CONTRIBUTING.md § Changesets.

**The changeset here is a patch for the four dictionaries.** Published data, types, and exports are
unchanged — the only difference in a tarball is the wider peer range, which is backwards-compatible
(everything valid under `^0.5.0` is still valid).

The rule is now written down in three places so it doesn't regress: `CHANGELOG.md` (versioning policy),
`CONTRIBUTING.md` (§ Changesets), and `CLAUDE.md` — name a dictionary in a changeset only when that
dictionary itself changed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)