### PR TITLE
chore(api): refresh the API-diff baseline to the released 0.5.2

### DIFF
--- a/packages/fix/api/baseline.json
+++ b/packages/fix/api/baseline.json
@@ -1,6 +1,6 @@
 {
   "note": "Structural API of the last published release — regenerate with scripts/refresh-api-baseline.mjs after each release.",
-  "version": "0.5.1",
+  "version": "0.5.2",
   "symbols": [
     {
       "id": "BaseType",


### PR DESCRIPTION
The documented post-release step from [`docs/api-json.md`](docs/api-json.md): re-baseline the API-diff gate on the just-published 0.5.2. Structurally identical surface — the version stamp alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)