### PR TITLE
chore(release): fold the API-baseline refresh into the Version Packages PR

### DIFF
--- a/docs/api-json.md
+++ b/docs/api-json.md
@@ -93,18 +93,29 @@ key on: boar.team withholds example rendering from any version that does not
 carry it. The claim's chain of trust is the repo's CI — the doctest gates
 every PR into `main`, and releases build from `main`.
 
-## Release-time maintenance
+## Release-time maintenance (automated)
 
-After each publish of `@boarteam/fix`, from the released commit:
+The baseline refresh rides inside the changesets **"Version Packages" PR** —
+no post-release chore PR exists. The root `version-packages` script (which the
+release workflow's changesets action invokes) chains three steps:
+
+1. `changeset version` — consume changesets, bump `package.json`s;
+2. `pnpm --filter @boarteam/fix build` — rebuild, re-running the emit gates
+   against the _old_ baseline (the version delta equals the consumed
+   changesets' level by construction, so a legitimate surface passes);
+3. `scripts/refresh-api-baseline.mjs` — re-stamp `api/baseline.json` from the
+   just-built surface at the _new_ version and freeze `"next"` since-entries.
+
+All three land in the bot's release PR, so the commit that publishes is the
+commit whose baseline already describes it — at publish time the gate compares
+the surface against itself. A release that does not touch `@boarteam/fix`
+leaves both files byte-identical (the refresh is a no-op at an unchanged
+version).
+
+The manual form remains for recovery (e.g. a baseline regenerated outside a
+release):
 
 ```bash
 pnpm --filter @boarteam/fix build
 node packages/fix/scripts/refresh-api-baseline.mjs
 ```
-
-This freezes `"next"` since-entries to the released version and makes the new
-release the diff baseline. (Until it runs, the gate diffs against the previous
-release with the version delta widening what is allowed — safe, just less
-precise.) The published artifact itself is always correct without this step:
-at publish time `package.json` already carries the new version, so `"next"`
-resolves to it inside the emitted `api.json`.

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
     "check:bundle": "node scripts/check-bundle.mjs",
     "examples": "node examples/parse-and-validate.mjs && node examples/encode-a-message.mjs && node examples/demo-decode.mjs snapshot && node examples/demo-decode.mjs broken && node examples/fixt-pair.mjs",
     "changeset": "changeset",
-    "version-packages": "changeset version",
+    "version-packages": "changeset version && pnpm --filter @boarteam/fix build && node packages/fix/scripts/refresh-api-baseline.mjs",
     "release": "pnpm -r build && changeset publish"
   },
   "devDependencies": {

--- a/packages/fix/scripts/refresh-api-baseline.mjs
+++ b/packages/fix/scripts/refresh-api-baseline.mjs
@@ -1,6 +1,9 @@
 #!/usr/bin/env node
-/* Post-release maintenance for the API contract files — run once after each
- * publish of @boarteam/fix (see docs/api-json.md):
+/* Maintenance for the API contract files. Runs AUTOMATICALLY as the tail of
+ * the root `version-packages` script, so the changesets "Version Packages" PR
+ * carries the refreshed baseline and no post-release chore PR is needed (see
+ * docs/api-json.md § Release-time maintenance). Kept runnable by hand for
+ * recovery:
  *
  *   1. api/baseline.json becomes the just-released structural surface, so the
  *      next PR diffs against the version users actually have;
@@ -10,6 +13,7 @@
  * Reads the CURRENT build output — run `pnpm --filter @boarteam/fix build`
  * first, from the released commit.
  */
+import { execFileSync } from 'node:child_process';
 import { readFileSync, writeFileSync } from 'node:fs';
 import { dirname, join } from 'node:path';
 import { fileURLToPath } from 'node:url';
@@ -48,6 +52,17 @@ for (const [name, version] of Object.entries(since)) {
   }
 }
 writeFileSync(sincePath, JSON.stringify(since, null, 2) + '\n');
+
+/* Prettier-format the outputs so a no-op refresh is byte-identical to the
+ * committed files — the version-packages chain must not churn the release PR
+ * with formatting-only diffs. */
+execFileSync(
+  'pnpm',
+  ['exec', 'prettier', '--write', join(PKG_DIR, 'api', 'baseline.json'), sincePath],
+  {
+    stdio: 'ignore',
+  },
+);
 
 console.log(
   `[api] baseline refreshed to ${pkg.version} (${symbols.length} symbols)` +


### PR DESCRIPTION
Answers "how do we avoid PRs like #47": by making the release PR itself carry the refresh, so there is nothing left to do after a publish.

## The mechanism

The changesets action already runs `pnpm version-packages` when it opens/refreshes the **"chore(release): version packages"** PR. That script now chains:

1. `changeset version` — consume changesets, bump versions;
2. `pnpm --filter @boarteam/fix build` — re-runs the emit gates against the *old* baseline; the version delta equals the consumed changesets' level by construction, so a legitimate surface passes;
3. `refresh-api-baseline.mjs` — re-stamps `api/baseline.json` at the *new* version from the just-built surface, and freezes `"next"` since-entries.

All of it lands in the bot's release PR. The commit that publishes is the commit whose baseline already describes it — at publish time the diff gate compares the surface against itself, and after the merge there is no trailing chore: #39/#44/#47 simply stop existing.

## Details

- The refresh script now prettier-formats its outputs, so a refresh at an unchanged version is **byte-identical** — releases that don't touch `@boarteam/fix` add zero diff to the release PR.
- Dry-run verified locally with no pending changesets: the chain exits green and leaves the tree clean.
- Manual invocation is kept for recovery and documented in [`docs/api-json.md`](docs/api-json.md).
- No changeset on this PR: release machinery only, nothing published changes (and `.changeset/**` is untouched, so the release workflow doesn't trigger).

🤖 Generated with [Claude Code](https://claude.com/claude-code)