### PR TITLE
docs: parse() needs a loaded dictionary in the inbound README snippets

### DIFF
--- a/.changeset/olive-pans-repeat.md
+++ b/.changeset/olive-pans-repeat.md
@@ -1,0 +1,17 @@
+---
+'@boarteam/fix': patch
+---
+
+Fix the inbound README snippets: `parse` needs a loaded dictionary.
+
+The "Inbound messages" sections added in 0.6.0 showed `parse(raw, dictionary)` passing the
+dict package's `dictionary` export directly. That export is a `DictionaryJSON`, and `parse`
+takes `Dictionary | FixtDictionaries` — so the snippet as printed did not compile. Both
+READMEs now load it first (`loadDictionary(fix44)`), which is also the form the rest of the
+free-function path uses.
+
+Worth knowing, since it is what made the mistake easy: `toInbound`, `inboundKnownGuard`,
+`createMessage` and `createFixEngine` all accept `Dictionary | DictionaryJSON`, while
+`parse`, `parseAll`, `encode` and `validate` require a loaded `Dictionary`.
+
+Docs only — no API or behaviour change.

--- a/README.md
+++ b/README.md
@@ -284,9 +284,11 @@ if (isMessageType(message, MsgType.MarketDataSnapshotFullRefresh)) {
 The same per-message types work on the way **in**. `parse` above returns the wire faithfully but tag-keyed (`message.fields[262].value`, groups under `message.groups[268]`) — the right shape for a codec, the wrong one for application code, which ends up hand-writing a `switch (msgType)` plus a tag-to-field mapper per message. `toInbound` re-keys it by dictionary name, splits the standard header/trailer into a typed `envelope`, and hands back a read model that narrows per `MsgType`.
 
 ```ts
-import { inboundKnownGuard, parse, toInbound } from '@boarteam/fix';
-import { dictionary, MsgType, type MessageBodies } from '@boarteam/fix-dict-fix44';
+import { inboundKnownGuard, loadDictionary, parse, toInbound } from '@boarteam/fix';
+import { dictionary as fix44, MsgType, type MessageBodies } from '@boarteam/fix-dict-fix44';
 
+// The dict packages ship the dictionary as data; `parse` wants it indexed.
+const dictionary = loadDictionary(fix44);
 const isKnownInbound = inboundKnownGuard<MessageBodies>(dictionary);
 
 const { message, issues } = parse(raw, dictionary); // gate on `issues` first
@@ -386,7 +388,7 @@ venue packages (e.g. a future `@boarteam/fix-dict-fix44-ctrader`).
 
 ### Lower-level building blocks
 
-If you do not want the engine wrapper, the same capabilities are exported as free functions: `parse`, `parseAll`, `encode`, `validate`, `tokenize`, `splitMessages`, `decodeValue`, `calculateChecksum`, `bodyLength`, `loadDictionary`, `Dictionary`, `validateDictionary`, the typed-message helpers (`messageFactory`, `messageTypeGuard`, `createMessage`, `createImmutableMessage`), and the dictionary-extension helpers (`extendDictionary`, `defineExtension`, `tagsOf`, `msgTypesOf`, `extendTags`, `invertTags`, `extendMsgTypes`, `invertMsgTypes`).
+If you do not want the engine wrapper, the same capabilities are exported as free functions: `parse`, `parseAll`, `encode`, `validate`, `tokenize`, `splitMessages`, `decodeValue`, `calculateChecksum`, `bodyLength`, `loadDictionary`, `Dictionary`, `validateDictionary`, the typed-message helpers (`messageFactory`, `messageTypeGuard`, `createMessage`, `createImmutableMessage`, `toInbound`, `inboundTypeGuard`, `inboundKnownGuard`), and the dictionary-extension helpers (`extendDictionary`, `defineExtension`, `tagsOf`, `msgTypesOf`, `extendTags`, `invertTags`, `extendMsgTypes`, `invertMsgTypes`).
 
 Every one of them is documented, signature by signature, in the [API reference](https://boar.team/fix/docs/api/).
 

--- a/packages/fix/README.md
+++ b/packages/fix/README.md
@@ -126,9 +126,11 @@ already knows. `toInbound` re-keys it by name, so a received message reads the w
 does.
 
 ```ts
-import { inboundKnownGuard, parse, toInbound } from '@boarteam/fix';
-import { dictionary, MsgType, type MessageBodies } from '@boarteam/fix-dict-fix44';
+import { inboundKnownGuard, loadDictionary, parse, toInbound } from '@boarteam/fix';
+import { dictionary as fix44, MsgType, type MessageBodies } from '@boarteam/fix-dict-fix44';
 
+// The dict packages ship the dictionary as data; `parse` wants it indexed.
+const dictionary = loadDictionary(fix44);
 const isKnownInbound = inboundKnownGuard<MessageBodies>(dictionary);
 
 const { message, issues } = parse(raw, dictionary); // gate on `issues` first


### PR DESCRIPTION
## What & why

The "Inbound messages" / "Reading an inbound message" sections shipped in 0.6.0 print this:

```ts
const { message, issues } = parse(raw, dictionary);
```

`dictionary` from a dict package is a `DictionaryJSON`; `parse` takes `Dictionary | FixtDictionaries`. **The snippet as printed does not compile.** Both READMEs now `loadDictionary(fix44)` first.

Caught downstream, not here: the boar.team site type-checks every docs sample against the installed package and rejected the snippet the moment the site was upgraded to 0.6.0. The corrected form was verified by compiling it against the published 0.6.0 before this PR.

Also lists `toInbound` / `inboundTypeGuard` / `inboundKnownGuard` in the root README's free-function rundown, which still named only the write-side helpers.

## Type of change

- [x] Bug fix (parse/validate/encode/dictionary) — documentation defect, no code change
- [ ] New feature
- [x] Docs / examples
- [ ] Tooling / CI
- [ ] Breaking change (output shape, accepted input, or issue codes — see SECURITY/CHANGELOG policy)

## Checklist

- [x] `pnpm -r build && pnpm -r typecheck` pass
- [x] `pnpm lint && pnpm format:check` pass
- [x] `pnpm test` passes (Node + browser-like env, examples)
- [x] `pnpm check:bundle` passes (no `net`/`Buffer`/`crypto`/`joi`/`@nestjs` in published output)
- [x] Added a Changeset if this changes a published package (`pnpm changeset`) — patch
- [x] Dictionary data (`fix-dict-fix44`) was **regenerated** with the spec tooling, not hand-edited — *no dictionary data touched*
- [x] Commits are signed off (`git commit -s`) per the DCO — see CONTRIBUTING.md

## Notes for reviewers

The asymmetry that made this easy to get wrong is worth a look on its own: `toInbound`, `inboundKnownGuard`, `createMessage` and `createFixEngine` all accept `Dictionary | DictionaryJSON`, while `parse`, `parseAll`, `encode` and `validate` require a loaded `Dictionary`. Nothing here is inconsistent by design — the loaders were added where the ergonomics obviously wanted them — but a reader moving between the engine façade and the free functions hits it.

The deeper gap is that **nothing in this repo compiles README fences.** The doctest gate covers TSDoc `@example` blocks and `pnpm examples` covers `examples/*.mjs`; the READMEs — the npm landing page — sit outside both, which is how this reached a published release. Worth a follow-up gate that extracts ```ts fences and type-checks them.

🤖 Generated with [Claude Code](https://claude.com/claude-code)